### PR TITLE
Extend TripodParameters to include T0

### DIFF
--- a/libraries/cer_kinematics/include/cer_kinematics/private/arm_common.h
+++ b/libraries/cer_kinematics/include/cer_kinematics/private/arm_common.h
@@ -27,7 +27,7 @@ protected:
 
     double drho;
 
-    Matrix T0,TN;
+    Matrix TN;
     double zd1,zd2;
     double wpostural_torso;
     double wpostural_torso_yaw;
@@ -49,7 +49,7 @@ public:
                  slv(slv_), torso(slv_.armParameters.torso),
                  upper_arm(slv_.armParameters.upper_arm),
                  lower_arm(slv_.armParameters.lower_arm),
-                 T0(slv_.armParameters.T0), TN(slv_.armParameters.TN),
+                 TN(slv_.armParameters.TN),
                  zd1(slv_.slvParameters.torso_heave),
                  zd2(slv_.slvParameters.lower_arm_heave),
                  wpostural_torso(slv_.slvParameters.weight_postural_torso),
@@ -132,6 +132,11 @@ public:
             d.T(2,0)=q31; d.T(2,1)=q32; d.T(2,2)=q33;  d.T(2,3)=d.p[2];
         }
 
+        d.n=params.R0*d.n+params.p0;
+        d.u=params.R0*d.u+params.p0;
+        d.p=params.R0*d.p+params.p0;
+        d.T=params.T0*d.T;
+
         return d;
     }
 
@@ -141,7 +146,7 @@ public:
         TripodState d1=tripod_fkin(1,x);
         TripodState d2=tripod_fkin(2,x);
 
-        return T0*d1.T*upper_arm.getH(CTRL_DEG2RAD*x.subVector(3,8))*d2.T*TN;
+        return d1.T*upper_arm.getH(CTRL_DEG2RAD*x.subVector(3,8))*d2.T*TN;
     }
 
     /****************************************************************/
@@ -151,7 +156,7 @@ public:
             return fkin(x);
 
         TripodState d1=tripod_fkin(1,x);
-        Matrix T=T0*d1.T;
+        Matrix T=d1.T;
 
         if (frame>=3)
         {
@@ -222,9 +227,9 @@ public:
             d1=tripod_fkin(1,x);
             d2=tripod_fkin(2,x);
             H=upper_arm.getH(q);
-            T=T0*d1.T*H*d2.T*TN;
+            T=d1.T*H*d2.T*TN;
 
-            upper_arm.setH0(T0*d1.T*H0); upper_arm.setHN(HN*d2.T*TN);
+            upper_arm.setH0(d1.T*H0); upper_arm.setHN(HN*d2.T*TN);
             H_=upper_arm.getH(q);
             J_=upper_arm.GeoJacobian();
             upper_arm.setH0(H0); upper_arm.setHN(HN);

--- a/libraries/cer_kinematics/include/cer_kinematics/private/arm_full.h
+++ b/libraries/cer_kinematics/include/cer_kinematics/private/arm_full.h
@@ -157,19 +157,19 @@ public:
 
         x_dx[0]=x[0]+drho;
         d_fw=tripod_fkin(1,x_dx);
-        e_fw=dcm2axis(Rd*SE3inv(T0*d_fw.T*M)); e_fw*=e_fw[3]; e_fw.pop_back();
+        e_fw=dcm2axis(Rd*SE3inv(d_fw.T*M)); e_fw*=e_fw[3]; e_fw.pop_back();
         grad_f[0]=2.0*(dot(e,e_fw-e)/drho + wpostural_torso*(x[0]-x[1]));
         x_dx[0]=x[0];
 
         x_dx[1]=x[1]+drho;
         d_fw=tripod_fkin(1,x_dx);
-        e_fw=dcm2axis(Rd*SE3inv(T0*d_fw.T*M)); e_fw*=e_fw[3]; e_fw.pop_back();
+        e_fw=dcm2axis(Rd*SE3inv(d_fw.T*M)); e_fw*=e_fw[3]; e_fw.pop_back();
         grad_f[1]=2.0*(dot(e,e_fw-e)/drho + wpostural_torso*(2.0*x[1]-x[0]-x[2]));
         x_dx[1]=x[1];
 
         x_dx[2]=x[2]+drho;
         d_fw=tripod_fkin(1,x_dx);
-        e_fw=dcm2axis(Rd*SE3inv(T0*d_fw.T*M)); e_fw*=e_fw[3]; e_fw.pop_back();
+        e_fw=dcm2axis(Rd*SE3inv(d_fw.T*M)); e_fw*=e_fw[3]; e_fw.pop_back();
         grad_f[2]=2.0*(dot(e,e_fw-e)/drho + wpostural_torso*(x[2]-x[1]));
         x_dx[2]=x[2];
 
@@ -182,7 +182,7 @@ public:
             grad_f[3+i]=grad[i] + 2.0*wpostural_upper_arm*(x[3+i]-x0[3+i]);
 
         // lower_arm
-        M=T0*d1.T*H;
+        M=d1.T*H;
 
         x_dx[9]=x[9]+drho;
         d_fw=tripod_fkin(2,x_dx);
@@ -321,19 +321,19 @@ public:
 
             x_dx[0]=x[0]+drho;
             d_fw=tripod_fkin(1,x_dx);
-            e_fw=xd-(T0*d_fw.T*M).getCol(3).subVector(0,2);
+            e_fw=xd-(d_fw.T*M).getCol(3).subVector(0,2);
             values[12]=2.0*dot(e,e_fw-e)/drho;
             x_dx[0]=x[0];
 
             x_dx[1]=x[1]+drho;
             d_fw=tripod_fkin(1,x_dx);
-            e_fw=xd-(T0*d_fw.T*M).getCol(3).subVector(0,2);
+            e_fw=xd-(d_fw.T*M).getCol(3).subVector(0,2);
             values[13]=2.0*dot(e,e_fw-e)/drho;
             x_dx[1]=x[1];
 
             x_dx[2]=x[2]+drho;
             d_fw=tripod_fkin(1,x_dx);
-            e_fw=xd-(T0*d_fw.T*M).getCol(3).subVector(0,2);
+            e_fw=xd-(d_fw.T*M).getCol(3).subVector(0,2);
             values[14]=2.0*dot(e,e_fw-e)/drho;
             x_dx[2]=x[2];
 
@@ -343,7 +343,7 @@ public:
                 values[15+i]=grad[i];
 
             // g[4] (lower_arm)
-            M=T0*d1.T*H;
+            M=d1.T*H;
 
             x_dx[9]=x[9]+drho;
             d_fw=tripod_fkin(2,x_dx);
@@ -406,28 +406,28 @@ public:
 
         x_dx[0]=x[0]+drho;
         d_fw=tripod_fkin(1,x_dx);
-        e_fw=dcm2axis(Rd*SE3inv(T0*d_fw.T*M)); e_fw*=e_fw[3]; e_fw.pop_back();
+        e_fw=dcm2axis(Rd*SE3inv(d_fw.T*M)); e_fw*=e_fw[3]; e_fw.pop_back();
         x_dx[0]=x[0]-drho;
         d_bw=tripod_fkin(1,x_dx);
-        e_bw=dcm2axis(Rd*SE3inv(T0*d_bw.T*M)); e_bw*=e_bw[3]; e_bw.pop_back();
+        e_bw=dcm2axis(Rd*SE3inv(d_bw.T*M)); e_bw*=e_bw[3]; e_bw.pop_back();
         grad_f[0]=dot(e,e_fw-e_bw)/drho + 2.0*wpostural_torso*(x[0]-x[1]);
         x_dx[0]=x[0];
 
         x_dx[1]=x[1]+drho;
         d_fw=tripod_fkin(1,x_dx);
-        e_fw=dcm2axis(Rd*SE3inv(T0*d_fw.T*M)); e_fw*=e_fw[3]; e_fw.pop_back();
+        e_fw=dcm2axis(Rd*SE3inv(d_fw.T*M)); e_fw*=e_fw[3]; e_fw.pop_back();
         x_dx[1]=x[1]-drho;
         d_bw=tripod_fkin(1,x_dx);
-        e_bw=dcm2axis(Rd*SE3inv(T0*d_bw.T*M)); e_bw*=e_bw[3]; e_bw.pop_back();
+        e_bw=dcm2axis(Rd*SE3inv(d_bw.T*M)); e_bw*=e_bw[3]; e_bw.pop_back();
         grad_f[1]=dot(e,e_fw-e_bw)/drho + 2.0*wpostural_torso*(2.0*x[1]-x[0]-x[2]);
         x_dx[1]=x[1];
 
         x_dx[2]=x[2]+drho;
         d_fw=tripod_fkin(1,x_dx);
-        e_fw=dcm2axis(Rd*SE3inv(T0*d_fw.T*M)); e_fw*=e_fw[3]; e_fw.pop_back();
+        e_fw=dcm2axis(Rd*SE3inv(d_fw.T*M)); e_fw*=e_fw[3]; e_fw.pop_back();
         x_dx[2]=x[2]-drho;
         d_bw=tripod_fkin(1,x_dx);
-        e_bw=dcm2axis(Rd*SE3inv(T0*d_bw.T*M)); e_bw*=e_bw[3]; e_bw.pop_back();
+        e_bw=dcm2axis(Rd*SE3inv(d_bw.T*M)); e_bw*=e_bw[3]; e_bw.pop_back();
         grad_f[2]=dot(e,e_fw-e_bw)/drho + 2.0*wpostural_torso*(x[2]-x[1]);
         x_dx[2]=x[2];
 
@@ -440,7 +440,7 @@ public:
             grad_f[3+i]=grad[i] + 2.0*wpostural_upper_arm*(x[3+i]-x0[3+i]);
 
         // lower_arm
-        M=T0*d1.T*H;
+        M=d1.T*H;
 
         x_dx[9]=x[9]+drho;
         d_fw=tripod_fkin(2,x_dx);
@@ -581,28 +581,28 @@ public:
 
             x_dx[0]=x[0]+drho;
             d_fw=tripod_fkin(1,x_dx);
-            e_fw=xd-(T0*d_fw.T*M).getCol(3).subVector(0,2);
+            e_fw=xd-(d_fw.T*M).getCol(3).subVector(0,2);
             x_dx[0]=x[0]-drho;
             d_bw=tripod_fkin(1,x_dx);
-            e_bw=xd-(T0*d_bw.T*M).getCol(3).subVector(0,2);
+            e_bw=xd-(d_bw.T*M).getCol(3).subVector(0,2);
             values[12]=dot(e,e_fw-e_bw)/drho;
             x_dx[0]=x[0];
 
             x_dx[1]=x[1]+drho;
             d_fw=tripod_fkin(1,x_dx);
-            e_fw=xd-(T0*d_fw.T*M).getCol(3).subVector(0,2);
+            e_fw=xd-(d_fw.T*M).getCol(3).subVector(0,2);
             x_dx[1]=x[1]-drho;
             d_bw=tripod_fkin(1,x_dx);
-            e_bw=xd-(T0*d_bw.T*M).getCol(3).subVector(0,2);
+            e_bw=xd-(d_bw.T*M).getCol(3).subVector(0,2);
             values[13]=dot(e,e_fw-e_bw)/drho;
             x_dx[1]=x[1];
 
             x_dx[2]=x[2]+drho;
             d_fw=tripod_fkin(1,x_dx);
-            e_fw=xd-(T0*d_fw.T*M).getCol(3).subVector(0,2);
+            e_fw=xd-(d_fw.T*M).getCol(3).subVector(0,2);
             x_dx[2]=x[2]-drho;
             d_bw=tripod_fkin(1,x_dx);
-            e_bw=xd-(T0*d_bw.T*M).getCol(3).subVector(0,2);
+            e_bw=xd-(d_bw.T*M).getCol(3).subVector(0,2);
             values[14]=dot(e,e_fw-e_bw)/drho;
             x_dx[2]=x[2];
 
@@ -612,7 +612,7 @@ public:
                 values[15+i]=grad[i];
 
             // g[4] (lower_arm)
-            M=T0*d1.T*H;
+            M=d1.T*H;
 
             x_dx[9]=x[9]+drho;
             d_fw=tripod_fkin(2,x_dx);

--- a/libraries/cer_kinematics/include/cer_kinematics/private/arm_full_heave.h
+++ b/libraries/cer_kinematics/include/cer_kinematics/private/arm_full_heave.h
@@ -169,19 +169,19 @@ public:
 
             x_dx[0]=x[0]+drho;
             d_fw=tripod_fkin(1,x_dx);
-            e_fw=xd-(T0*d_fw.T*M).getCol(3).subVector(0,2);
+            e_fw=xd-(d_fw.T*M).getCol(3).subVector(0,2);
             values[6]=2.0*dot(e,e_fw-e)/drho;
             x_dx[0]=x[0];
 
             x_dx[1]=x[1]+drho;
             d_fw=tripod_fkin(1,x_dx);
-            e_fw=xd-(T0*d_fw.T*M).getCol(3).subVector(0,2);
+            e_fw=xd-(d_fw.T*M).getCol(3).subVector(0,2);
             values[7]=2.0*dot(e,e_fw-e)/drho;
             x_dx[1]=x[1];
 
             x_dx[2]=x[2]+drho;
             d_fw=tripod_fkin(1,x_dx);
-            e_fw=xd-(T0*d_fw.T*M).getCol(3).subVector(0,2);
+            e_fw=xd-(d_fw.T*M).getCol(3).subVector(0,2);
             values[8]=2.0*dot(e,e_fw-e)/drho;
             x_dx[2]=x[2];
 
@@ -191,7 +191,7 @@ public:
                 values[9+i]=grad[i];
 
             // g[3] (lower_arm)
-            M=T0*d1.T*H;
+            M=d1.T*H;
 
             x_dx[9]=x[9]+drho;
             d_fw=tripod_fkin(2,x_dx);
@@ -382,28 +382,28 @@ public:
 
             x_dx[0]=x[0]+drho;
             d_fw=tripod_fkin(1,x_dx);
-            e_fw=xd-(T0*d_fw.T*M).getCol(3).subVector(0,2);
+            e_fw=xd-(d_fw.T*M).getCol(3).subVector(0,2);
             x_dx[0]=x[0]-drho;
             d_bw=tripod_fkin(1,x_dx);
-            e_bw=xd-(T0*d_bw.T*M).getCol(3).subVector(0,2);
+            e_bw=xd-(d_bw.T*M).getCol(3).subVector(0,2);
             values[6]=dot(e,e_fw-e_bw)/drho;
             x_dx[0]=x[0];
 
             x_dx[1]=x[1]+drho;
             d_fw=tripod_fkin(1,x_dx);
-            e_fw=xd-(T0*d_fw.T*M).getCol(3).subVector(0,2);
+            e_fw=xd-(d_fw.T*M).getCol(3).subVector(0,2);
             x_dx[1]=x[1]-drho;
             d_bw=tripod_fkin(1,x_dx);
-            e_bw=xd-(T0*d_bw.T*M).getCol(3).subVector(0,2);
+            e_bw=xd-(d_bw.T*M).getCol(3).subVector(0,2);
             values[7]=dot(e,e_fw-e_bw)/drho;
             x_dx[1]=x[1];
 
             x_dx[2]=x[2]+drho;
             d_fw=tripod_fkin(1,x_dx);
-            e_fw=xd-(T0*d_fw.T*M).getCol(3).subVector(0,2);
+            e_fw=xd-(d_fw.T*M).getCol(3).subVector(0,2);
             x_dx[2]=x[2]-drho;
             d_bw=tripod_fkin(1,x_dx);
-            e_bw=xd-(T0*d_bw.T*M).getCol(3).subVector(0,2);
+            e_bw=xd-(d_bw.T*M).getCol(3).subVector(0,2);
             values[8]=dot(e,e_fw-e_bw)/drho;
             x_dx[2]=x[2];
 
@@ -413,7 +413,7 @@ public:
                 values[9+i]=grad[i];
 
             // g[3] (lower_arm)
-            M=T0*d1.T*H;
+            M=d1.T*H;
 
             x_dx[9]=x[9]+drho;
             d_fw=tripod_fkin(2,x_dx);

--- a/libraries/cer_kinematics/include/cer_kinematics/private/arm_xyz.h
+++ b/libraries/cer_kinematics/include/cer_kinematics/private/arm_xyz.h
@@ -151,19 +151,19 @@ public:
 
         x_dx[0]=x[0]+drho;
         d_fw=tripod_fkin(1,x_dx);
-        e_fw=xd-(T0*d_fw.T*M).getCol(3).subVector(0,2);
+        e_fw=xd-(d_fw.T*M).getCol(3).subVector(0,2);
         grad_f[0]=2.0*(dot(e,e_fw-e)/drho + wpostural_torso*(x[0]-x[1]));
         x_dx[0]=x[0];
 
         x_dx[1]=x[1]+drho;
         d_fw=tripod_fkin(1,x_dx);
-        e_fw=xd-(T0*d_fw.T*M).getCol(3).subVector(0,2);
+        e_fw=xd-(d_fw.T*M).getCol(3).subVector(0,2);
         grad_f[1]=2.0*(dot(e,e_fw-e)/drho + wpostural_torso*(2.0*x[1]-x[0]-x[2]));
         x_dx[1]=x[1];
 
         x_dx[2]=x[2]+drho;
         d_fw=tripod_fkin(1,x_dx);
-        e_fw=xd-(T0*d_fw.T*M).getCol(3).subVector(0,2);
+        e_fw=xd-(d_fw.T*M).getCol(3).subVector(0,2);
         grad_f[2]=2.0*(dot(e,e_fw-e)/drho + wpostural_torso*(x[2]-x[1]));
         x_dx[2]=x[2];
 
@@ -174,7 +174,7 @@ public:
             grad_f[3+i]=grad[i] + 2.0*wpostural_upper_arm*(x[3+i]-x0[3+i]);
 
         // g[4] (lower_arm)
-        M=T0*d1.T*H;
+        M=d1.T*H;
 
         x_dx[9]=x[9]+drho;
         d_fw=tripod_fkin(2,x_dx);
@@ -335,28 +335,28 @@ public:
 
         x_dx[0]=x[0]+drho;
         d_fw=tripod_fkin(1,x_dx);
-        e_fw=xd-(T0*d_fw.T*M).getCol(3).subVector(0,2);
+        e_fw=xd-(d_fw.T*M).getCol(3).subVector(0,2);
         x_dx[0]=x[0]-drho;
         d_bw=tripod_fkin(1,x_dx);
-        e_bw=xd-(T0*d_bw.T*M).getCol(3).subVector(0,2);
+        e_bw=xd-(d_bw.T*M).getCol(3).subVector(0,2);
         grad_f[0]=dot(e,e_fw-e_bw)/drho + 2.0*wpostural_torso*(x[0]-x[1]);
         x_dx[0]=x[0];
 
         x_dx[1]=x[1]+drho;
         d_fw=tripod_fkin(1,x_dx);
-        e_fw=xd-(T0*d_fw.T*M).getCol(3).subVector(0,2);
+        e_fw=xd-(d_fw.T*M).getCol(3).subVector(0,2);
         x_dx[1]=x[1]-drho;
         d_bw=tripod_fkin(1,x_dx);
-        e_bw=xd-(T0*d_bw.T*M).getCol(3).subVector(0,2);
+        e_bw=xd-(d_bw.T*M).getCol(3).subVector(0,2);
         grad_f[1]=dot(e,e_fw-e_bw)/drho + 2.0*wpostural_torso*(2.0*x[1]-x[0]-x[2]);
         x_dx[1]=x[1];
 
         x_dx[2]=x[2]+drho;
         d_fw=tripod_fkin(1,x_dx);
-        e_fw=xd-(T0*d_fw.T*M).getCol(3).subVector(0,2);
+        e_fw=xd-(d_fw.T*M).getCol(3).subVector(0,2);
         x_dx[2]=x[2]-drho;
         d_bw=tripod_fkin(1,x_dx);
-        e_bw=xd-(T0*d_bw.T*M).getCol(3).subVector(0,2);
+        e_bw=xd-(d_bw.T*M).getCol(3).subVector(0,2);
         grad_f[2]=dot(e,e_fw-e_bw)/drho + 2.0*wpostural_torso*(x[2]-x[1]);
         x_dx[2]=x[2];
 
@@ -367,7 +367,7 @@ public:
             grad_f[3+i]=grad[i] + 2.0*wpostural_upper_arm*(x[3+i]-x0[3+i]);
 
         // g[4] (lower_arm)
-        M=T0*d1.T*H;
+        M=d1.T*H;
 
         x_dx[9]=x[9]+drho;
         d_fw=tripod_fkin(2,x_dx);

--- a/libraries/cer_kinematics/include/cer_kinematics/private/helpers.h
+++ b/libraries/cer_kinematics/include/cer_kinematics/private/helpers.h
@@ -38,6 +38,9 @@ struct TripodParametersExtended : public TripodParameters
     std::deque<yarp::sig::Vector> s;
     yarp::sig::Vector z;
 
+    yarp::sig::Matrix R0;
+    yarp::sig::Vector p0;
+
     /****************************************************************/
     TripodParametersExtended(const TripodParameters &parameters) :
                              TripodParameters(parameters)
@@ -57,6 +60,9 @@ struct TripodParametersExtended : public TripodParameters
 
             theta+=CTRL_DEG2RAD*120.0;
         }
+
+        R0=T0.submatrix(0,2,0,2);
+        p0=T0.getCol(3).subVector(0,2);
     }
 };
 

--- a/libraries/cer_kinematics/include/cer_kinematics/utils.h
+++ b/libraries/cer_kinematics/include/cer_kinematics/utils.h
@@ -20,6 +20,7 @@
 
 #include <string>
 #include <yarp/sig/Matrix.h>
+#include <yarp/math/Math.h>
 #include <iCub/iKin/iKinFwd.h>
 
 namespace cer_kinematics
@@ -53,6 +54,12 @@ struct TripodParameters
     double alpha_max;
 
     /**
+     * the 4-by-4 homogeneous matrix linking the root frame to the 
+     * tripod ([m]).
+     */
+    yarp::sig::Matrix T0;
+
+    /**
      * Constructor.
      * 
      * @param r_        the radius ([m]).
@@ -61,8 +68,13 @@ struct TripodParameters
      * @param alpha_max the maximum permitted bending angle ([deg]).
      */
     TripodParameters(const double r_=0.09, const double l_min_=-0.05,
-                     const double l_max_=0.15, const double alpha_max_=30.0) :
-                     r(r_), l_min(l_min_), l_max(l_max_), alpha_max(alpha_max_) { }
+                     const double l_max_=0.15, const double alpha_max_=30.0,
+                     const yarp::sig::Matrix T0_=yarp::math::eye(4,4)) :
+                     r(r_), l_min(l_min_),  l_max(l_max_),
+                     alpha_max(alpha_max_), T0(T0_)
+    {
+        yAssert((T0.rows()==4) && (T0.cols()==4));
+    }
 };
 
 
@@ -73,12 +85,6 @@ struct TripodParameters
  */
 struct ArmParameters
 {
-    /**
-     * the 4-by-4 homogeneous matrix linking the root frame and the 
-     * torso. 
-     */
-    yarp::sig::Matrix T0;
-
     /**
      * the tripod mechanism for the torso.
      */
@@ -96,7 +102,7 @@ struct ArmParameters
 
     /**
      * the 4-by-4 homogeneous matrix linking the lower_arm with the 
-     * end-effector frame. 
+     * end-effector frame ([m]).
      */
     yarp::sig::Matrix TN;
 

--- a/libraries/cer_kinematics/src/tripod.cpp
+++ b/libraries/cer_kinematics/src/tripod.cpp
@@ -126,6 +126,11 @@ public:
             d.T(2,0)=q31; d.T(2,1)=q32; d.T(2,2)=q33;  d.T(2,3)=d.p[2];
         }
 
+        d.n=params.R0*d.n+params.p0;
+        d.u=params.R0*d.u+params.p0;
+        d.p=params.R0*d.p+params.p0;
+        d.T=params.T0*d.T;
+
         return d;
     }
 

--- a/libraries/cer_kinematics/src/utils.cpp
+++ b/libraries/cer_kinematics/src/utils.cpp
@@ -102,7 +102,7 @@ ArmParameters::ArmParameters(const string &type) :
 {
     Vector rot(4,0.0);
     rot[2]=1.0; rot[3]=M_PI;
-    T0=axis2dcm(rot);
+    torso.T0=axis2dcm(rot);
 
     double hand_ang=CTRL_DEG2RAD*20.0;
     double hand_dist=0.07;


### PR DESCRIPTION
The `T0` matrix is brought within the tripod parameters structure, so that the forward kinematics can be computed also for a generic rotation of the tripod with respect to the root frame.

@barbalberto, by default `T0=yarp::math::eye(4,4);` but you should make this configurable. The new default value of `T0` for the torso tripod to be put in the `.ini` file is the outcome of the following operations:

``` cpp
Vector rot(4,0.0);
rot[2]=1.0; rot[3]=M_PI;
Matrix T0=axis2dcm(rot);
```

which is a rotation of `180 deg` around z-axis.

/cc @ale-git 
