### PR TITLE
Ipopt refinements 

### DIFF
--- a/libraries/cer_kinematics/include/cer_kinematics/private/arm_full_heave.h
+++ b/libraries/cer_kinematics/include/cer_kinematics/private/arm_full_heave.h
@@ -85,8 +85,8 @@ public:
     {
         computeQuantities(x,new_x);
 
-        g[0]=d1.n[2];
-        g[1]=d2.n[2];
+        g[0]=din1.n[2];
+        g[1]=din2.n[2];
         g[2]=norm2(xd-T.getCol(3).subVector(0,2));
 
         return true;
@@ -129,33 +129,33 @@ public:
 
             // g[0] (torso)
             x_dx[0]=x[0]+drho;
-            d_fw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_fw);
             values[0]=(d_fw.n[2]-d1.n[2])/drho;
             x_dx[0]=x[0];
 
             x_dx[1]=x[1]+drho;
-            d_fw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_fw);
             values[1]=(d_fw.n[2]-d1.n[2])/drho;
             x_dx[1]=x[1];
 
             x_dx[2]=x[2]+drho;
-            d_fw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_fw);
             values[2]=(d_fw.n[2]-d1.n[2])/drho;
             x_dx[2]=x[2];
 
             // g[1] (lower_arm)
             x_dx[9]=x[9]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             values[3]=(d_fw.n[2]-d2.n[2])/drho;
             x_dx[9]=x[9];
 
             x_dx[10]=x[10]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             values[4]=(d_fw.n[2]-d2.n[2])/drho;
             x_dx[10]=x[10];
 
             x_dx[11]=x[11]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             values[5]=(d_fw.n[2]-d2.n[2])/drho;
             x_dx[11]=x[11];
 
@@ -286,8 +286,8 @@ public:
     {
         computeQuantities(x,new_x);
 
-        g[0]=d1.n[2];
-        g[1]=d2.n[2];
+        g[0]=din1.n[2];
+        g[1]=din2.n[2];
         g[2]=norm2(xd-T.getCol(3).subVector(0,2));
 
         return true;
@@ -330,45 +330,45 @@ public:
 
             // g[0] (torso)
             x_dx[0]=x[0]+drho;
-            d_fw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_fw);
             x_dx[0]=x[0]-drho;
-            d_bw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_bw);
             values[0]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[0]=x[0];
 
             x_dx[1]=x[1]+drho;
-            d_fw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_fw);
             x_dx[1]=x[1]-drho;
-            d_bw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_bw);
             values[1]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[1]=x[1];
 
             x_dx[2]=x[2]+drho;
-            d_fw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_fw);
             x_dx[2]=x[2]-drho;
-            d_bw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_bw);
             values[2]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[2]=x[2];
 
             // g[1] (lower_arm)
             x_dx[9]=x[9]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             x_dx[9]=x[9]-drho;
-            d_bw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_bw);
             values[3]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[9]=x[9];
 
             x_dx[10]=x[10]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             x_dx[10]=x[10]-drho;
-            d_bw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_bw);
             values[4]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[10]=x[10];
 
             x_dx[11]=x[11]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             x_dx[11]=x[11]-drho;
-            d_bw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_bw);
             values[5]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[11]=x[11];
 

--- a/libraries/cer_kinematics/include/cer_kinematics/private/arm_full_heave.h
+++ b/libraries/cer_kinematics/include/cer_kinematics/private/arm_full_heave.h
@@ -76,6 +76,18 @@ public:
         g_l[1]=lower_arm.cos_alpha_max; g_u[1]=1.0;
         g_l[2]=g_u[2]=0.0;
 
+        latch_idx.clear();
+        latch_gl.clear();
+        latch_gu.clear();
+
+        latch_idx.push_back(0);
+        latch_gl.push_back(g_l[0]);
+        latch_gu.push_back(g_u[0]);
+
+        latch_idx.push_back(1);
+        latch_gl.push_back(g_l[1]);
+        latch_gu.push_back(g_u[1]);
+
         return true;
     }
 
@@ -88,6 +100,8 @@ public:
         g[0]=din1.n[2];
         g[1]=din2.n[2];
         g[2]=norm2(xd-T.getCol(3).subVector(0,2));
+
+        latch_x_verifying_alpha(n,x,g);
 
         return true;
     }
@@ -277,6 +291,18 @@ public:
         g_l[1]=lower_arm.cos_alpha_max; g_u[1]=1.0;
         g_l[2]=g_u[2]=0.0;
 
+        latch_idx.clear();
+        latch_gl.clear();
+        latch_gu.clear();
+
+        latch_idx.push_back(0);
+        latch_gl.push_back(g_l[0]);
+        latch_gu.push_back(g_u[0]);
+
+        latch_idx.push_back(1);
+        latch_gl.push_back(g_l[1]);
+        latch_gu.push_back(g_u[1]);
+
         return true;
     }
 
@@ -289,6 +315,8 @@ public:
         g[0]=din1.n[2];
         g[1]=din2.n[2];
         g[2]=norm2(xd-T.getCol(3).subVector(0,2));
+
+        latch_x_verifying_alpha(n,x,g);
 
         return true;
     }

--- a/libraries/cer_kinematics/include/cer_kinematics/private/arm_full_noheave.h
+++ b/libraries/cer_kinematics/include/cer_kinematics/private/arm_full_noheave.h
@@ -211,13 +211,13 @@ public:
     {
         computeQuantities(x,new_x);
 
-        double e1=hd1-d1.p[2];
+        double e1=hd1-din1.p[2];
         g[0]=e1*e1;
-        g[1]=d1.n[2];
+        g[1]=din1.n[2];
 
-        double e2=hd2-d2.p[2];
+        double e2=hd2-din2.p[2];
         g[2]=e2*e2;
-        g[3]=d2.n[2];
+        g[3]=din2.n[2];
 
         g[4]=norm2(xd-T.getCol(3).subVector(0,2));
 
@@ -270,43 +270,43 @@ public:
             TripodState d_fw;
 
             // g[0,1] (torso)
-            double e1=hd1-d1.p[2];
+            double e1=hd1-din1.p[2];
 
             x_dx[0]=x[0]+drho;
-            d_fw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_fw);
             values[0]=-2.0*e1*(d_fw.p[2]-d1.p[2])/drho;
             values[3]=(d_fw.n[2]-d1.n[2])/drho;
             x_dx[0]=x[0];
 
             x_dx[1]=x[1]+drho;
-            d_fw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_fw);
             values[1]=-2.0*e1*(d_fw.p[2]-d1.p[2])/drho;
             values[4]=(d_fw.n[2]-d1.n[2])/drho;
             x_dx[1]=x[1];
 
             x_dx[2]=x[2]+drho;
-            d_fw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_fw);
             values[2]=-2.0*e1*(d_fw.p[2]-d1.p[2])/drho;
             values[5]=(d_fw.n[2]-d1.n[2])/drho;
             x_dx[2]=x[2];
 
             // g[2,3] (lower_arm)
-            double e2=hd2-d2.p[2];
+            double e2=hd2-din2.p[2];
 
             x_dx[9]=x[9]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             values[6]=-2.0*e2*(d_fw.p[2]-d2.p[2])/drho;
             values[9]=(d_fw.n[2]-d2.n[2])/drho;
             x_dx[9]=x[9];
 
             x_dx[10]=x[10]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             values[7]=-2.0*e2*(d_fw.p[2]-d2.p[2])/drho;
             values[10]=(d_fw.n[2]-d2.n[2])/drho;
             x_dx[10]=x[10];
 
             x_dx[11]=x[11]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             values[8]=-2.0*e2*(d_fw.p[2]-d2.p[2])/drho;
             values[11]=(d_fw.n[2]-d2.n[2])/drho;
             x_dx[11]=x[11];
@@ -518,55 +518,55 @@ public:
             TripodState d_fw,d_bw;
 
             // g[0,1] (torso)
-            double e1=hd1-d1.p[2];
+            double e1=hd1-din1.p[2];
 
             x_dx[0]=x[0]+drho;
-            d_fw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_fw);
             x_dx[0]=x[0]-drho;
-            d_bw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_bw);
             values[0]=-e1*(d_fw.p[2]-d_bw.p[2])/drho;
             values[3]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[0]=x[0];
 
             x_dx[1]=x[1]+drho;
-            d_fw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_fw);
             x_dx[1]=x[1]-drho;
-            d_bw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_bw);
             values[1]=-e1*(d_fw.p[2]-d_bw.p[2])/drho;
             values[4]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[1]=x[1];
 
             x_dx[2]=x[2]+drho;
-            d_fw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_fw);
             x_dx[2]=x[2]-drho;
-            d_bw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_bw);
             values[2]=-e1*(d_fw.p[2]-d_bw.p[2])/drho;
             values[5]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[2]=x[2];
 
             // g[2,3] (lower_arm)
-            double e2=hd2-d2.p[2];
+            double e2=hd2-din2.p[2];
 
             x_dx[9]=x[9]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             x_dx[9]=x[9]-drho;
-            d_bw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_bw);
             values[6]=-e2*(d_fw.p[2]-d_bw.p[2])/drho;
             values[9]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[9]=x[9];
 
             x_dx[10]=x[10]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             x_dx[10]=x[10]-drho;
-            d_bw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_bw);
             values[7]=-e2*(d_fw.p[2]-d_bw.p[2])/drho;
             values[10]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[10]=x[10];
 
             x_dx[11]=x[11]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             x_dx[11]=x[11]-drho;
-            d_bw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_bw);
             values[8]=-e2*(d_fw.p[2]-d_bw.p[2])/drho;
             values[11]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[11]=x[11];

--- a/libraries/cer_kinematics/include/cer_kinematics/private/arm_full_noheave.h
+++ b/libraries/cer_kinematics/include/cer_kinematics/private/arm_full_noheave.h
@@ -80,6 +80,18 @@ public:
 
         g_l[4]=g_u[4]=0.0;
 
+        latch_idx.clear();
+        latch_gl.clear();
+        latch_gu.clear();
+
+        latch_idx.push_back(1);
+        latch_gl.push_back(g_l[1]);
+        latch_gu.push_back(g_u[1]);
+
+        latch_idx.push_back(3);
+        latch_gl.push_back(g_l[3]);
+        latch_gu.push_back(g_u[3]);
+
         return true;
     }
 
@@ -220,6 +232,8 @@ public:
         g[3]=din2.n[2];
 
         g[4]=norm2(xd-T.getCol(3).subVector(0,2));
+
+        latch_x_verifying_alpha(n,x,g);
 
         return true;
     }

--- a/libraries/cer_kinematics/include/cer_kinematics/private/arm_full_notorso.h
+++ b/libraries/cer_kinematics/include/cer_kinematics/private/arm_full_notorso.h
@@ -75,6 +75,14 @@ public:
 
         g_l[2]=g_u[2]=0.0;
 
+        latch_idx.clear();
+        latch_gl.clear();
+        latch_gu.clear();
+
+        latch_idx.push_back(1);
+        latch_gl.push_back(g_l[1]);
+        latch_gu.push_back(g_u[1]);
+
         return true;
     }
 
@@ -178,6 +186,8 @@ public:
         g[1]=din2.n[2];
 
         g[2]=norm2(xd-T.getCol(3).subVector(0,2));
+
+        latch_x_verifying_alpha(n,x,g);
 
         return true;
     }

--- a/libraries/cer_kinematics/include/cer_kinematics/private/arm_full_notorso.h
+++ b/libraries/cer_kinematics/include/cer_kinematics/private/arm_full_notorso.h
@@ -173,9 +173,9 @@ public:
     {
         computeQuantities(x,new_x);
 
-        double e2=hd2-d2.p[2];
+        double e2=hd2-din2.p[2];
         g[0]=e2*e2;
-        g[1]=d2.n[2];
+        g[1]=din2.n[2];
 
         g[2]=norm2(xd-T.getCol(3).subVector(0,2));
 
@@ -218,22 +218,22 @@ public:
             TripodState d_fw;
 
             // g[0,1] (lower_arm)
-            double e2=hd2-d2.p[2];
+            double e2=hd2-din2.p[2];
 
             x_dx[9]=x[9]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             values[0]=-2.0*e2*(d_fw.p[2]-d2.p[2])/drho;
             values[3]=(d_fw.n[2]-d2.n[2])/drho;
             x_dx[9]=x[9];
 
             x_dx[10]=x[10]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             values[1]=-2.0*e2*(d_fw.p[2]-d2.p[2])/drho;
             values[4]=(d_fw.n[2]-d2.n[2])/drho;
             x_dx[10]=x[10];
 
             x_dx[11]=x[11]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             values[2]=-2.0*e2*(d_fw.p[2]-d2.p[2])/drho;
             values[5]=(d_fw.n[2]-d2.n[2])/drho;
             x_dx[11]=x[11];
@@ -386,28 +386,28 @@ public:
             TripodState d_fw,d_bw;
 
             // g[0,1] (lower_arm)
-            double e2=hd2-d2.p[2];
+            double e2=hd2-din2.p[2];
 
             x_dx[9]=x[9]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             x_dx[9]=x[9]-drho;
-            d_bw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_bw);
             values[0]=-e2*(d_fw.p[2]-d_bw.p[2])/drho;
             values[3]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[9]=x[9];
 
             x_dx[10]=x[10]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             x_dx[10]=x[10]-drho;
-            d_bw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_bw);
             values[1]=-e2*(d_fw.p[2]-d_bw.p[2])/drho;
             values[4]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[10]=x[10];
 
             x_dx[11]=x[11]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             x_dx[11]=x[11]-drho;
-            d_bw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_bw);
             values[2]=-e2*(d_fw.p[2]-d_bw.p[2])/drho;
             values[5]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[11]=x[11];

--- a/libraries/cer_kinematics/include/cer_kinematics/private/arm_xyz_heave.h
+++ b/libraries/cer_kinematics/include/cer_kinematics/private/arm_xyz_heave.h
@@ -83,8 +83,8 @@ public:
                 Ipopt::Index m, Ipopt::Number *g)
     {
         computeQuantities(x,new_x);
-        g[0]=d1.n[2];
-        g[1]=d2.n[2];
+        g[0]=din1.n[2];
+        g[1]=din2.n[2];
 
         return true;
     }
@@ -118,33 +118,33 @@ public:
 
             // g[0] (torso)
             x_dx[0]=x[0]+drho;
-            d_fw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_fw);
             values[0]=(d_fw.n[2]-d1.n[2])/drho;
             x_dx[0]=x[0];
 
             x_dx[1]=x[1]+drho;
-            d_fw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_fw);
             values[1]=(d_fw.n[2]-d1.n[2])/drho;
             x_dx[1]=x[1];
 
             x_dx[2]=x[2]+drho;
-            d_fw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_fw);
             values[2]=(d_fw.n[2]-d1.n[2])/drho;
             x_dx[2]=x[2];
 
             // g[1] (lower_arm)
             x_dx[9]=x[9]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             values[3]=(d_fw.n[2]-d2.n[2])/drho;
             x_dx[9]=x[9];
 
             x_dx[10]=x[10]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             values[4]=(d_fw.n[2]-d2.n[2])/drho;
             x_dx[10]=x[10];
 
             x_dx[11]=x[11]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             values[5]=(d_fw.n[2]-d2.n[2])/drho;
             x_dx[11]=x[11];
         }
@@ -221,8 +221,8 @@ public:
                 Ipopt::Index m, Ipopt::Number *g)
     {
         computeQuantities(x,new_x);
-        g[0]=d1.n[2];
-        g[1]=d2.n[2];
+        g[0]=din1.n[2];
+        g[1]=din2.n[2];
 
         return true;
     }
@@ -256,45 +256,45 @@ public:
 
             // g[0] (torso)
             x_dx[0]=x[0]+drho;
-            d_fw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_fw);
             x_dx[0]=x[0]-drho;
-            d_bw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_bw);
             values[0]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[0]=x[0];
 
             x_dx[1]=x[1]+drho;
-            d_fw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_fw);
             x_dx[1]=x[1]-drho;
-            d_bw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_bw);
             values[1]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[1]=x[1];
 
             x_dx[2]=x[2]+drho;
-            d_fw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_fw);
             x_dx[2]=x[2]-drho;
-            d_bw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_bw);
             values[2]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[2]=x[2];
 
             // g[1] (lower_arm)
             x_dx[9]=x[9]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             x_dx[9]=x[9]-drho;
-            d_bw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_bw);
             values[3]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[9]=x[9];
 
             x_dx[10]=x[10]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             x_dx[10]=x[10]-drho;
-            d_bw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_bw);
             values[4]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[10]=x[10];
 
             x_dx[11]=x[11]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             x_dx[11]=x[11]-drho;
-            d_bw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_bw);
             values[5]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[11]=x[11];
         }

--- a/libraries/cer_kinematics/include/cer_kinematics/private/arm_xyz_heave.h
+++ b/libraries/cer_kinematics/include/cer_kinematics/private/arm_xyz_heave.h
@@ -75,6 +75,18 @@ public:
         g_l[0]=torso.cos_alpha_max;     g_u[0]=1.0;
         g_l[1]=lower_arm.cos_alpha_max; g_u[1]=1.0;
 
+        latch_idx.clear();
+        latch_gl.clear();
+        latch_gu.clear();
+
+        latch_idx.push_back(0);
+        latch_gl.push_back(g_l[0]);
+        latch_gu.push_back(g_u[0]);
+
+        latch_idx.push_back(1);
+        latch_gl.push_back(g_l[1]);
+        latch_gu.push_back(g_u[1]);
+
         return true;
     }
 
@@ -85,6 +97,8 @@ public:
         computeQuantities(x,new_x);
         g[0]=din1.n[2];
         g[1]=din2.n[2];
+
+        latch_x_verifying_alpha(n,x,g);
 
         return true;
     }
@@ -213,6 +227,18 @@ public:
         g_l[0]=torso.cos_alpha_max;     g_u[0]=1.0;
         g_l[1]=lower_arm.cos_alpha_max; g_u[1]=1.0;
 
+        latch_idx.clear();
+        latch_gl.clear();
+        latch_gu.clear();
+
+        latch_idx.push_back(0);
+        latch_gl.push_back(g_l[0]);
+        latch_gu.push_back(g_u[0]);
+
+        latch_idx.push_back(1);
+        latch_gl.push_back(g_l[1]);
+        latch_gu.push_back(g_u[1]);
+
         return true;
     }
 
@@ -223,6 +249,8 @@ public:
         computeQuantities(x,new_x);
         g[0]=din1.n[2];
         g[1]=din2.n[2];
+
+        latch_x_verifying_alpha(n,x,g);
 
         return true;
     }

--- a/libraries/cer_kinematics/include/cer_kinematics/private/arm_xyz_noheave.h
+++ b/libraries/cer_kinematics/include/cer_kinematics/private/arm_xyz_noheave.h
@@ -78,6 +78,18 @@ public:
         g_l[2]=g_u[2]=0.0;
         g_l[3]=lower_arm.cos_alpha_max; g_u[3]=1.0;
 
+        latch_idx.clear();
+        latch_gl.clear();
+        latch_gu.clear();
+
+        latch_idx.push_back(1);
+        latch_gl.push_back(g_l[1]);
+        latch_gu.push_back(g_u[1]);
+
+        latch_idx.push_back(3);
+        latch_gl.push_back(g_l[3]);
+        latch_gu.push_back(g_u[3]);
+
         return true;
     }
 
@@ -210,6 +222,8 @@ public:
         double e2=hd2-din2.p[2];
         g[2]=e2*e2;
         g[3]=din2.n[2];
+
+        latch_x_verifying_alpha(n,x,g);
 
         return true;
     }

--- a/libraries/cer_kinematics/include/cer_kinematics/private/arm_xyz_noheave.h
+++ b/libraries/cer_kinematics/include/cer_kinematics/private/arm_xyz_noheave.h
@@ -203,13 +203,13 @@ public:
     {
         computeQuantities(x,new_x);
 
-        double e1=hd1-d1.p[2];
+        double e1=hd1-din1.p[2];
         g[0]=e1*e1;
-        g[1]=d1.n[2];
+        g[1]=din1.n[2];
 
-        double e2=hd2-d2.p[2];
+        double e2=hd2-din2.p[2];
         g[2]=e2*e2;
-        g[3]=d2.n[2];
+        g[3]=din2.n[2];
 
         return true;
     }
@@ -252,43 +252,43 @@ public:
             TripodState d_fw;
 
             // g[0,1] (torso)
-            double e1=hd1-d1.p[2];
+            double e1=hd1-din1.p[2];
 
             x_dx[0]=x[0]+drho;
-            d_fw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_fw);
             values[0]=-2.0*e1*(d_fw.p[2]-d1.p[2])/drho;
             values[3]=(d_fw.n[2]-d1.n[2])/drho;
             x_dx[0]=x[0];
 
             x_dx[1]=x[1]+drho;
-            d_fw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_fw);
             values[1]=-2.0*e1*(d_fw.p[2]-d1.p[2])/drho;
             values[4]=(d_fw.n[2]-d1.n[2])/drho;
             x_dx[1]=x[1];
 
             x_dx[2]=x[2]+drho;
-            d_fw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_fw);
             values[2]=-2.0*e1*(d_fw.p[2]-d1.p[2])/drho;
             values[5]=(d_fw.n[2]-d1.n[2])/drho;
             x_dx[2]=x[2];
 
             // g[2,3] (lower_arm)
-            double e2=hd2-d2.p[2];
+            double e2=hd2-din2.p[2];
 
             x_dx[9]=x[9]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             values[6]=-2.0*e2*(d_fw.p[2]-d2.p[2])/drho;
             values[9]=(d_fw.n[2]-d2.n[2])/drho;
             x_dx[9]=x[9];
 
             x_dx[10]=x[10]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             values[7]=-2.0*e2*(d_fw.p[2]-d2.p[2])/drho;
             values[10]=(d_fw.n[2]-d2.n[2])/drho;
             x_dx[10]=x[10];
 
             x_dx[11]=x[11]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             values[8]=-2.0*e2*(d_fw.p[2]-d2.p[2])/drho;
             values[11]=(d_fw.n[2]-d2.n[2])/drho;
             x_dx[11]=x[11];
@@ -437,55 +437,55 @@ public:
             TripodState d_fw,d_bw;
 
             // g[0,1] (torso)
-            double e1=hd1-d1.p[2];
+            double e1=hd1-din1.p[2];
 
             x_dx[0]=x[0]+drho;
-            d_fw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_fw);
             x_dx[0]=x[0]-drho;
-            d_bw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_bw);
             values[0]=-e1*(d_fw.p[2]-d_bw.p[2])/drho;
             values[3]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[0]=x[0];
 
             x_dx[1]=x[1]+drho;
-            d_fw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_fw);
             x_dx[1]=x[1]-drho;
-            d_bw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_bw);
             values[1]=-e1*(d_fw.p[2]-d_bw.p[2])/drho;
             values[4]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[1]=x[1];
 
             x_dx[2]=x[2]+drho;
-            d_fw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_fw);
             x_dx[2]=x[2]-drho;
-            d_bw=tripod_fkin(1,x_dx);
+            tripod_fkin(1,x_dx,&d_bw);
             values[2]=-e1*(d_fw.p[2]-d_bw.p[2])/drho;
             values[5]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[2]=x[2];
 
             // g[2,3] (lower_arm)
-            double e2=hd2-d2.p[2];
+            double e2=hd2-din2.p[2];
 
             x_dx[9]=x[9]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             x_dx[9]=x[9]-drho;
-            d_bw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_bw);
             values[6]=-e2*(d_fw.p[2]-d_bw.p[2])/drho;
             values[9]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[9]=x[9];
 
             x_dx[10]=x[10]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             x_dx[10]=x[10]-drho;
-            d_bw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_bw);
             values[7]=-e2*(d_fw.p[2]-d_bw.p[2])/drho;
             values[10]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[10]=x[10];
 
             x_dx[11]=x[11]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             x_dx[11]=x[11]-drho;
-            d_bw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_bw);
             values[8]=-e2*(d_fw.p[2]-d_bw.p[2])/drho;
             values[11]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[11]=x[11];

--- a/libraries/cer_kinematics/include/cer_kinematics/private/arm_xyz_notorso.h
+++ b/libraries/cer_kinematics/include/cer_kinematics/private/arm_xyz_notorso.h
@@ -165,9 +165,9 @@ public:
     {
         computeQuantities(x,new_x);
 
-        double e2=hd2-d2.p[2];
+        double e2=hd2-din2.p[2];
         g[0]=e2*e2;
-        g[1]=d2.n[2];
+        g[1]=din2.n[2];
 
         return true;
     }
@@ -200,22 +200,22 @@ public:
             TripodState d_fw;
 
             // g[0,1] (lower_arm)
-            double e2=hd2-d2.p[2];
+            double e2=hd2-din2.p[2];
 
             x_dx[9]=x[9]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             values[0]=-2.0*e2*(d_fw.p[2]-d2.p[2])/drho;
             values[3]=(d_fw.n[2]-d2.n[2])/drho;
             x_dx[9]=x[9];
 
             x_dx[10]=x[10]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             values[1]=-2.0*e2*(d_fw.p[2]-d2.p[2])/drho;
             values[4]=(d_fw.n[2]-d2.n[2])/drho;
             x_dx[10]=x[10];
 
             x_dx[11]=x[11]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             values[2]=-2.0*e2*(d_fw.p[2]-d2.p[2])/drho;
             values[5]=(d_fw.n[2]-d2.n[2])/drho;
             x_dx[11]=x[11];
@@ -327,28 +327,28 @@ public:
             TripodState d_fw,d_bw;
 
             // g[2,3] (lower_arm)
-            double e2=hd2-d2.p[2];
+            double e2=hd2-din2.p[2];
 
             x_dx[9]=x[9]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             x_dx[9]=x[9]-drho;
-            d_bw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_bw);
             values[0]=-e2*(d_fw.p[2]-d_bw.p[2])/drho;
             values[3]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[9]=x[9];
 
             x_dx[10]=x[10]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             x_dx[10]=x[10]-drho;
-            d_bw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_bw);
             values[1]=-e2*(d_fw.p[2]-d_bw.p[2])/drho;
             values[4]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[10]=x[10];
 
             x_dx[11]=x[11]+drho;
-            d_fw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_fw);
             x_dx[11]=x[11]-drho;
-            d_bw=tripod_fkin(2,x_dx);
+            tripod_fkin(2,x_dx,&d_bw);
             values[2]=-e2*(d_fw.p[2]-d_bw.p[2])/drho;
             values[5]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[11]=x[11];

--- a/libraries/cer_kinematics/include/cer_kinematics/private/arm_xyz_notorso.h
+++ b/libraries/cer_kinematics/include/cer_kinematics/private/arm_xyz_notorso.h
@@ -70,8 +70,16 @@ public:
             x_u[offs+i]=lower_arm.l_max;
         }
 
+        latch_idx.clear();
+        latch_gl.clear();
+        latch_gu.clear();
+
         g_l[0]=g_u[0]=0.0;
         g_l[1]=lower_arm.cos_alpha_max; g_u[1]=1.0;
+
+        latch_idx.push_back(1);
+        latch_gl.push_back(g_l[1]);
+        latch_gu.push_back(g_u[1]);
 
         return true;
     }
@@ -168,6 +176,8 @@ public:
         double e2=hd2-din2.p[2];
         g[0]=e2*e2;
         g[1]=din2.n[2];
+
+        latch_x_verifying_alpha(n,x,g);
 
         return true;
     }

--- a/libraries/cer_kinematics/include/cer_kinematics/utils.h
+++ b/libraries/cer_kinematics/include/cer_kinematics/utils.h
@@ -18,6 +18,7 @@
 #ifndef __CER_KINEMATICS_UTILS_H__
 #define __CER_KINEMATICS_UTILS_H__
 
+#include <limits>
 #include <string>
 #include <yarp/sig/Matrix.h>
 #include <yarp/math/Math.h>
@@ -243,7 +244,8 @@ struct SolverParameters
                      const double weight_postural_upper_arm_=0.0,
                      const double weight_postural_lower_arm_=0.0,
                      const double tol_=0.1, const double constr_tol_=1e-4,
-                     const int max_iter_=500, const double max_cpu_time_=1.0,
+                     const int max_iter_=std::numeric_limits<int>::max(),
+                     const double max_cpu_time_=1.0,
                      const bool use_central_difference_=false,
                      const bool warm_start_=false) :
                      full_pose(full_pose_), configuration(configuration_),

--- a/libraries/cer_kinematics/src/arm.cpp
+++ b/libraries/cer_kinematics/src/arm.cpp
@@ -138,8 +138,9 @@ bool ArmSolver::ikin(const Matrix &Hd, Vector &q, int *exit_code)
     app->Options()->SetNumericValue("nlp_scaling_min_value",1e-6);
     app->Options()->SetStringValue("hessian_approximation","limited-memory");    
     app->Options()->SetStringValue("fixed_variable_treatment","make_parameter");
+    app->Options()->SetStringValue("expect_infeasible_problem","yes");
     app->Options()->SetStringValue("derivative_test",print_level>=4?"first-order":"none");
-    app->Options()->SetIntegerValue("print_level",print_level);    
+    app->Options()->SetIntegerValue("print_level",print_level);
     if (slvParameters.warm_start)
     {
         if ((zL.length()>0) && (zU.length()>0) && (lambda.length()>0) && (curMode==mode))
@@ -225,8 +226,9 @@ bool ArmSolver::ikin(const Matrix &Hd, Vector &q, int *exit_code)
         ud.pop_back();
 
         Matrix H=nlp->fkin(q);
-        TripodState d1=nlp->tripod_fkin(1,q);
-        TripodState d2=nlp->tripod_fkin(2,q);
+        TripodState din1,din2;
+        nlp->tripod_fkin(1,q,&din1);
+        nlp->tripod_fkin(2,q,&din2);
         Vector x=H.getCol(3).subVector(0,2);
         Vector u=dcm2axis(H);
         u*=u[3];
@@ -248,10 +250,10 @@ bool ArmSolver::ikin(const Matrix &Hd, Vector &q, int *exit_code)
         yInfo(" *** Arm Solver:            q [*] = (%s)",q.toString(4,4).c_str());
         yInfo(" *** Arm Solver:          e_x [m] = %g",norm(xd-x));
         yInfo(" *** Arm Solver:        e_u [rad] = %g",norm(ud-u));
-        yInfo(" *** Arm Solver:         e_h1 [m] = %g",fabs(slvParameters.torso_heave-d1.p[2]));
-        yInfo(" *** Arm Solver:     alpha1 [deg] = %g",CTRL_RAD2DEG*acos(d1.n[2]));
-        yInfo(" *** Arm Solver:         e_h2 [m] = %g",fabs(slvParameters.lower_arm_heave-d2.p[2]));
-        yInfo(" *** Arm Solver:     alpha2 [deg] = %g",CTRL_RAD2DEG*acos(d2.n[2]));
+        yInfo(" *** Arm Solver:         e_h1 [m] = %g",fabs(slvParameters.torso_heave-din1.p[2]));
+        yInfo(" *** Arm Solver:     alpha1 [deg] = %g",CTRL_RAD2DEG*acos(din1.n[2]));
+        yInfo(" *** Arm Solver:         e_h2 [m] = %g",fabs(slvParameters.lower_arm_heave-din2.p[2]));
+        yInfo(" *** Arm Solver:     alpha2 [deg] = %g",CTRL_RAD2DEG*acos(din2.n[2]));
         yInfo(" *** Arm Solver:          dt [ms] = %g",1000.0*(t1-t0));
         yInfo(" *** Arm Solver ******************************");
     }

--- a/libraries/cer_kinematics/src/arm.cpp
+++ b/libraries/cer_kinematics/src/arm.cpp
@@ -139,8 +139,8 @@ bool ArmSolver::ikin(const Matrix &Hd, Vector &q, int *exit_code)
     app->Options()->SetStringValue("hessian_approximation","limited-memory");
     app->Options()->SetStringValue("fixed_variable_treatment","make_parameter");
     app->Options()->SetStringValue("expect_infeasible_problem","yes");
-    app->Options()->SetNumericValue("expect_infeasible_problem_ctol",slvParameters.constr_tol);
-    app->Options()->SetNumericValue("expect_infeasible_problem_ytol",10.0*slvParameters.constr_tol);
+    app->Options()->SetNumericValue("expect_infeasible_problem_ctol",10.0*slvParameters.constr_tol);
+    app->Options()->SetNumericValue("expect_infeasible_problem_ytol",100.0*slvParameters.constr_tol);
     app->Options()->SetStringValue("derivative_test",print_level>=4?"first-order":"none");
     app->Options()->SetIntegerValue("print_level",print_level);
     if (slvParameters.warm_start)

--- a/libraries/cer_kinematics/src/arm.cpp
+++ b/libraries/cer_kinematics/src/arm.cpp
@@ -136,11 +136,11 @@ bool ArmSolver::ikin(const Matrix &Hd, Vector &q, int *exit_code)
     app->Options()->SetStringValue("nlp_scaling_method","gradient-based");
     app->Options()->SetNumericValue("nlp_scaling_max_gradient",1.0);
     app->Options()->SetNumericValue("nlp_scaling_min_value",1e-6);
-    app->Options()->SetStringValue("hessian_approximation","limited-memory");    
+    app->Options()->SetStringValue("hessian_approximation","limited-memory");
     app->Options()->SetStringValue("fixed_variable_treatment","make_parameter");
     app->Options()->SetStringValue("expect_infeasible_problem","yes");
-    app->Options()->SetNumericValue("expect_infeasible_problem_ctol",10.0*slvParameters.constr_tol);
-    app->Options()->SetNumericValue("expect_infeasible_problem_ytol",1e-2);
+    app->Options()->SetNumericValue("expect_infeasible_problem_ctol",slvParameters.constr_tol);
+    app->Options()->SetNumericValue("expect_infeasible_problem_ytol",10.0*slvParameters.constr_tol);
     app->Options()->SetStringValue("derivative_test",print_level>=4?"first-order":"none");
     app->Options()->SetIntegerValue("print_level",print_level);
     if (slvParameters.warm_start)

--- a/libraries/cer_kinematics/src/arm.cpp
+++ b/libraries/cer_kinematics/src/arm.cpp
@@ -139,6 +139,8 @@ bool ArmSolver::ikin(const Matrix &Hd, Vector &q, int *exit_code)
     app->Options()->SetStringValue("hessian_approximation","limited-memory");    
     app->Options()->SetStringValue("fixed_variable_treatment","make_parameter");
     app->Options()->SetStringValue("expect_infeasible_problem","yes");
+    app->Options()->SetNumericValue("expect_infeasible_problem_ctol",10.0*slvParameters.constr_tol);
+    app->Options()->SetNumericValue("expect_infeasible_problem_ytol",1e-2);
     app->Options()->SetStringValue("derivative_test",print_level>=4?"first-order":"none");
     app->Options()->SetIntegerValue("print_level",print_level);
     if (slvParameters.warm_start)

--- a/tests/test-cer_kinematics-b2b.cpp
+++ b/tests/test-cer_kinematics-b2b.cpp
@@ -16,7 +16,6 @@
 */
 
 #include <cmath>
-#include <limits>
 #include <string>
 #include <sstream>
 #include <deque>
@@ -104,8 +103,6 @@ int main()
 
     SolverParameters p=solver_0.getSolverParameters();
     p.setMode("full_pose");
-    p.max_iter=std::numeric_limits<int>::max();
-    p.max_cpu_time=0.5;
     p.warm_start=true;
     solver_0.setSolverParameters(p);
 

--- a/tests/test-cer_kinematics-b2b.cpp
+++ b/tests/test-cer_kinematics-b2b.cpp
@@ -149,13 +149,14 @@ int main()
 
         Matrix H_tmp0;
         solver_0.fkin(q_1,H_tmp0,0);
+        H_tmp0=SE3inv(armParams.torso.T0)*H_tmp0; 
         double h1=H_tmp0(2,3);
         double alpha1=R2D*acos(H_tmp0(2,2));
 
         Matrix H_tmp1;
         solver_0.fkin(q_1,H_tmp1,8);
         solver_0.fkin(q_1,H_tmp0,9);
-        H_tmp0=SE3inv(H_tmp1)*H_tmp0;
+        H_tmp0=SE3inv(H_tmp1*armParams.lower_arm.T0)*H_tmp0; 
         double h2=H_tmp0(2,3);
         double alpha2=R2D*acos(H_tmp0(2,2));
 


### PR DESCRIPTION
This PR applies the following changes to `cer_kinematics` library:
##### Bug Fixes
- Fixed returned joints configuration when `max_cpu_time` was exceeded.
  Given that reaching in position is handled as a nonlinear constraint, exactly as the bounds accounting for the tripod maximum bending angles (`alpha`), it happened sometimes that Ipopt tried hard to comply with reaching in position, even though it was not possible, running out of all the time budget and thus allowing for a slight violation on alphas. Now bounds on alphas are always honored, no matter of targets' locations.
- Fixed potential pitfall while checking against tripod constraints in case the initial roto-translation matrices (`torso.T0` and `lower_arm.T0`) are not given as a pure rotation around z-axis (which represents the current configuration by the way).
##### Improvements
- By means of `expect_infeasible_problem` option, we can tell Ipopt that the final target might be out-of-reach. This way, the restoration phase is called more often, resulting in a lower overall computation time. This option can be always left on, working also in case of attainable targets.
