### PR TITLE
Face display update

### DIFF
--- a/cermod/faceDisplayClient/faceDisplayClient.cpp
+++ b/cermod/faceDisplayClient/faceDisplayClient.cpp
@@ -45,14 +45,27 @@ bool cer::dev::FaceDisplayClient::open(yarp::os::Searchable &config)
 
     if (!rpcPort.open(local.c_str()))
     {
-        yError("FaceDisplayClient::open() error could not open rpc port %s, check network", local.c_str());
+        yError("FaceDisplayClient: could not open rpc port %s", local.c_str());
         return false;
     }
 
-    bool ok=Network::connect(local.c_str(), remote.c_str());
+    if(! imagePort.open(local+"/image:o") )
+    {
+        yError() <<  "FaceDisplayClient: could not open streaming port" << local + "/image:o";
+        return false;
+    }
+
+    bool ok=Network::connect(local.c_str(), (remote+"/rpc"));
     if (!ok)
     {
-        yError("FaceDisplayClient::open() error could not connect to %s\n", remote.c_str());
+        yError("FaceDisplayClient: could not connect to %s\n", (remote+"/rpc").c_str());
+        return false;
+    }
+
+    ok = Network::connect((local+"/image:o").c_str(), (remote+"/image:i").c_str());
+    if (!ok)
+    {
+        yError("FaceDisplayClient: could not connect to %s\n", (remote+"/image:i").c_str());
         return false;
     }
 

--- a/cermod/faceDisplayClient/faceDisplayClient.cpp
+++ b/cermod/faceDisplayClient/faceDisplayClient.cpp
@@ -86,6 +86,7 @@ bool FaceDisplayClient::setFaceExpression(int faceId)
 {
     yTrace() << "\n\tset face" << yarp::os::Vocab::decode(faceId);
     Bottle cmd;
+    cmd.addVocab(VOCAB_SET);
     cmd.addVocab(VOCAB_FACE);
     cmd.addVocab(faceId);
 
@@ -95,14 +96,17 @@ bool FaceDisplayClient::setFaceExpression(int faceId)
 bool FaceDisplayClient::getFaceExpression(int* faceId)
 {
     yTrace();
-    yError() << "Not Yet Implemented FaceDisplayClient::getFaceExpression";
-    return false;
+    Bottle cmd;
+    cmd.addVocab(VOCAB_GET);
+    cmd.addVocab(VOCAB_FACE);
+
+    return rpcPort.write(cmd);
 }
 
 bool FaceDisplayClient::setImageFile(std::string fileName)
 {
-    yTrace() << "\n\tset image" << fileName;
     Bottle cmd;
+    cmd.addVocab(VOCAB_SET);
     cmd.addVocab(VOCAB_FILE);
     cmd.addString(fileName);
 
@@ -112,20 +116,32 @@ bool FaceDisplayClient::setImageFile(std::string fileName)
 bool FaceDisplayClient::getImageFile(std::string& fileName)
 {
     yTrace();
-    yError() << "Not Yet Implemented FaceDisplayClient::getFaceExpression";
-    return false;
+    Bottle cmd;
+    cmd.addVocab(VOCAB_GET);
+    cmd.addVocab(VOCAB_FACE);
+    return rpcPort.write(cmd);
 }
 
+bool FaceDisplayClient::setImage(yarp::sig::Image img)
+{
+    yTrace();
+    yarp::sig::Image & imgSend =  imagePort.prepare();
+    imgSend = img;
+    imagePort.write();
+    return true;
+}
 
+bool FaceDisplayClient::getImage(yarp::sig::Image* img)
+{
+    Bottle cmd;
+    cmd.addVocab(VOCAB_GET);
+    cmd.addVocab(VOCAB_IMAGE);
 
+    bool ret =rpcPort.write(cmd);
 
+    if(ret)
+        *img = *imagePort.read();
 
-
-
-
-
-
-
-
-
+    return ret;
+}
 

--- a/cermod/faceDisplayClient/faceDisplayClient.h
+++ b/cermod/faceDisplayClient/faceDisplayClient.h
@@ -8,12 +8,12 @@
 #define CER_DEV_FACEDISPLAYCLIENT_H
 
 
+#include <yarp/sig/Image.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/dev/PolyDriver.h>
 
 #include <IFaceDisplayInterface.h>
-
 
 namespace cer {
     namespace dev {
@@ -53,6 +53,7 @@ class cer::dev::FaceDisplayClient:  public yarp::dev::DeviceDriver,
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 protected:
     yarp::os::Port rpcPort;
+    yarp::os::BufferedPort<yarp::sig::FlexImage>  imagePort;
     yarp::os::ConstString local;
     yarp::os::ConstString remote;
     std::string deviceId;
@@ -75,6 +76,9 @@ public:
 
     bool setImageFile(std::string fileName);
     bool getImageFile(std::string &fileName);
+
+    virtual bool setImage(yarp::sig::Image  img);
+    virtual bool getImage(yarp::sig::Image *img);
 };
 
 #endif // CER_DEV_FACEDISPLAYCLIENT_H

--- a/cermod/faceDisplayServer/CMakeLists.txt
+++ b/cermod/faceDisplayServer/CMakeLists.txt
@@ -4,7 +4,9 @@
 
 yarp_prepare_device(faceDisplayServer TYPE cer::dev::FaceDisplayServer INCLUDE faceDisplayServer.h)
 
- IF (ENABLE_faceDisplayServer)
+project(FaceDisplayServer)
+
+IF (ENABLE_faceDisplayServer)
 
   find_package(OpenCV REQUIRED)
 

--- a/cermod/faceDisplayServer/CMakeLists.txt
+++ b/cermod/faceDisplayServer/CMakeLists.txt
@@ -8,7 +8,13 @@ project(FaceDisplayServer)
 
 IF (ENABLE_faceDisplayServer)
 
-  find_package(OpenCV REQUIRED)
+  ## Use opencv
+  find_package(OpenCV)
+  if(NOT OpenCV_FOUND)
+      message(WARNING "OpenCV was not found therefore FaceDisplayServer cannot be compiled. Please disable it or install OpenCV.")
+      return()
+  endif(NOT OpenCV_FOUND)
+
 
   include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${YARP_INCLUDE_DIRS} ${OPENCV_INCLUDE_DIR})
 

--- a/cermod/faceDisplayServer/IFaceDisplayInterface.h
+++ b/cermod/faceDisplayServer/IFaceDisplayInterface.h
@@ -8,10 +8,15 @@
 #define CER_DEV_FACEDISPLAY_INTERFACE_H_
 
 #include <yarp/os/Vocab.h>
+#include <yarp/sig/Image.h>
 
 // VOCABS
+#define VOCAB_SET         VOCAB3('s','e','t')
+#define VOCAB_GET         VOCAB3('g','e','t')
+
 #define VOCAB_FACE          VOCAB4('f','a','c','e')
 #define VOCAB_FILE          VOCAB4('f','i','l','e')
+#define VOCAB_IMAGE         VOCAB3('i','m','g')
 
 #define VOCAB_FACE_HAPPY    VOCAB3('h','a','p')
 #define VOCAB_FACE_SAD      VOCAB3('s','a','d')
@@ -36,6 +41,9 @@ public:
 
     virtual bool setImageFile(std::string fileName) = 0;
     virtual bool getImageFile(std::string &fileName) = 0;
+
+    virtual bool setImage(yarp::sig::Image  img) = 0;
+    virtual bool getImage(yarp::sig::Image *img) = 0;
 };
 
 #endif // CER_DEV_FACEDISPLAY_INTERFACE_H_

--- a/cermod/faceDisplayServer/faceDisplayServer.cpp
+++ b/cermod/faceDisplayServer/faceDisplayServer.cpp
@@ -37,18 +37,6 @@ FaceDisplayServer::~FaceDisplayServer()
     threadRelease();
 }
 
-bool FaceDisplayServer::attachAll(const PolyDriverList &analog2attach)
-{
-    yError() << "FaceDisplayServer: Attach metod is not yet implemented";
-    return false;
-}
-
-bool FaceDisplayServer::detachAll()
-{
-    yError() << "FaceDisplayServer: Detach metod is not yet implemented";
-    return false;
-}
-
 void FaceDisplayServer::setId(const std::string &id)
 {
     sensorId=id;

--- a/cermod/faceDisplayServer/faceDisplayServer.cpp
+++ b/cermod/faceDisplayServer/faceDisplayServer.cpp
@@ -87,8 +87,10 @@ bool FaceDisplayServer::open(yarp::os::Searchable &config)
     // THIS SET THE DEAD TIME -- magic numbers from Francesco Diotalevi
     gen_reg.offset=CER_TIME;
     gen_reg.rw=WRITE_REGISTER;
-    gen_reg.data=0x440063;
-    ioctl (fd, IOC_GEN_REG, &gen_reg);
+    gen_reg.data=0x220063;
+//     gen_reg.data=0x110063;
+    ioctl(fd, IOC_GEN_REG, &gen_reg);
+
 
     // start the thread
     start();

--- a/cermod/faceDisplayServer/faceDisplayServer.cpp
+++ b/cermod/faceDisplayServer/faceDisplayServer.cpp
@@ -8,9 +8,13 @@
 #include <yarp/os/LogStream.h>
 #include <sys/ioctl.h>
 #include <fcntl.h>
-#include<opencv/cv.h>
-#include<opencv/cxcore.h>
-#include<opencv/highgui.h>
+#include <opencv/cv.h>
+#include <opencv/cxcore.h>
+#include <opencv/highgui.h>
+
+#include <opencv2/core/mat.hpp>
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
 
 #include <faceDisplayServer.h>
 #include <IFaceDisplayInterface.h>
@@ -26,9 +30,12 @@ using namespace std;
   */
 
 // Constructor used when there is only one output port
-FaceDisplayServer::FaceDisplayServer()
+FaceDisplayServer::FaceDisplayServer(): sensorId("low-res display"),
+                                        selfTest(0),
+                                        imagePort(&mutex)
 {
     yTrace();
+    color_choise = 0;
 }
 
 FaceDisplayServer::~FaceDisplayServer()
@@ -50,26 +57,16 @@ std::string FaceDisplayServer::getId()
 bool FaceDisplayServer::open(yarp::os::Searchable &config)
 {
     Property params;
+    yarp::os::ConstString   rpcPortName, imagePortName;
+
     params.fromString(config.toString().c_str());
-    yTrace() << "AnalogServer params are: " << config.toString();
+    yTrace() << "FaceDisplayServer params are: " << config.toString();
 
-    if (!config.check("name"))
-    {
-        yError() << "AnalogServer: missing 'name' parameter. This parameter defines the name of ports opened by this device, i.e. '/robot/faceDisplay'. \n\
-        Please correct the configuration file\n";
-        return false;
-    }
-    else
-         rpcPortName = config.find("name").asString();
+    rpcPortName   = config.check("name", yarp::os::Value("/robot/faceDisplay/rpc"), "Name of the port receiving input commands").toString();
+    imagePortName = config.check("name", yarp::os::Value("/robot/faceDisplay/image:i"), "Name of the port receiving images").toString();
 
-    if (!config.check("display"))
-    {
-        yError() << "AnalogServer: missing 'display' parameter. This parameter defines the name of the device file to use in the system, i.e. '/dev/auxdisp'. \n\
-        Please correct the configuration file\n";
-        return false;
-    }
-    else
-         deviceFileName = config.find("display").asString();
+    deviceFileName = config.check("display", yarp::os::Value("/dev/auxdisp"), "Device file to use in the system, i.e. '/dev/auxdisp'").toString();
+    rootPath = config.check("path", yarp::os::Value("/home/linaro/AUXDISP"), "Where images are located").toString();
 
     if(!rpcPort.open(rpcPortName))
     {
@@ -77,12 +74,49 @@ bool FaceDisplayServer::open(yarp::os::Searchable &config)
         return false;
     }
 
+    imagePort.useCallback();                    // input images will go to onRead() callback
+    if(!imagePort.open(imagePortName))
+    {
+        yError() << "Failed to open port " << imagePortName.c_str();
+        return false;
+    }
+
     // open device file and init some stuff
     if ((fd=::open(deviceFileName.c_str(), O_RDWR)) < 0)
     {
-        yError() << "Cannot open device file " << deviceFileName;
+        yError() << "Cannot open device file " << deviceFileName.c_str();
         return false;
     }
+
+    if (config.check("red"))
+    {
+        color_choise = 0;
+        yInfo() << "RED";
+    }
+
+    if (config.check("green"))
+    {
+        color_choise = 1;
+        yInfo() << "GREEN";
+    }
+
+    if (config.check("blue"))
+    {
+        color_choise = 2;
+        yInfo() << "BLUE";
+    }
+
+    if (config.check("selfTest"))
+    {
+        selfTest = config.check("selfTest", yarp::os::Value(1), "Run one of the selt tests from (1 to 3)").asInt();
+        yWarning() << "Device working in selfTest " << selfTest << " mode.";
+    }
+
+    // used in selfTestmode 2 for now, maybe useful also for automatic transitions later on ... ???
+    steps = config.check("steps", yarp::os::Value(30), "Number of transition between start and end").asInt();
+
+    if(steps <=0)
+        yError() << "Number of steps must be a positive integer";
 
     // THIS SET THE DEAD TIME -- magic numbers from Francesco Diotalevi
     gen_reg.offset=CER_TIME;
@@ -91,6 +125,17 @@ bool FaceDisplayServer::open(yarp::os::Searchable &config)
 //     gen_reg.data=0x110063;
     ioctl(fd, IOC_GEN_REG, &gen_reg);
 
+    // set 24 bit of color per pixel
+    ioctl(fd,IOC_SET_BPP,BPP24);
+
+
+    // clear display
+    cv::Mat black(IMAGE_HEIGHT,IMAGE_WIDTH, CV_8UC3, cv::Scalar(0,0,0));
+    mutex.wait();
+    if(-1 == ::write(fd, black.data, black.total()*3) )
+        yError() << "Failed setting image to display";
+    mutex.post();
+    imagePort.init(fd);
 
     // start the thread
     start();
@@ -100,7 +145,6 @@ bool FaceDisplayServer::open(yarp::os::Searchable &config)
 void FaceDisplayServer::onStop()
 {
     yTrace();
-    ::close(fd);
     rpcPort.interrupt();
     rpcPort.close();
 }
@@ -110,13 +154,230 @@ void FaceDisplayServer::run()
     yarp::os::Bottle command;
     char imageFileName[255];
 
-    int command_vocab;
-    int param;
+    int action, type, param;
 
+    if(selfTest == 1)
+    {
+        // preload the images
+        IplImage *img[10];
+
+        img[0] = cvLoadImage(yarp::os::ConstString(rootPath + "/RobotE_PNG_80x32_16bit_01.bmp").c_str(), 1);
+        img[1] = cvLoadImage(yarp::os::ConstString(rootPath + "/RobotE_PNG_80x32_16bit_02.bmp").c_str(), 1);
+        img[2] = cvLoadImage(yarp::os::ConstString(rootPath + "/RobotE_PNG_80x32_16bit_03.bmp").c_str(), 1);
+        img[3] = cvLoadImage(yarp::os::ConstString(rootPath + "/RobotE_PNG_80x32_16bit_03_clean.bmp").c_str(), 1);
+        img[4] = cvLoadImage(yarp::os::ConstString(rootPath + "/RobotE_PNG_80x32_16bit_04.bmp").c_str(), 1);
+
+        img[5] = cvLoadImage(yarp::os::ConstString(rootPath + "/RobotE_PNG_80x32_16bit_05.bmp").c_str(), 1);
+        img[6] = cvLoadImage(yarp::os::ConstString(rootPath + "/Anger.bmp").c_str(), 1);
+        img[7] = cvLoadImage(yarp::os::ConstString(rootPath + "/balette.bmp").c_str(), 1);
+        img[8] = cvLoadImage(yarp::os::ConstString(rootPath + "/CCPP2.bmp").c_str(), 1);
+        img[9] = cvLoadImage(yarp::os::ConstString(rootPath + "/CCPP4.bmp").c_str(), 1);
+
+
+        yInfo() << "width is " << img[0]->width << "height" << img[0]->height;
+
+        // Convert into BGR
+        for(int i=0; i<10; i++)
+        {
+            if(img[i] == NULL)
+                yError() << "img not valid at index " << i;
+
+            cvCvtColor(img[i], img[i], CV_BGR2RGB);
+
+            if(img[i] == NULL)
+                yError() << "img not valid at index " << i;
+        }
+
+
+        double  last, elapsedTime, start;
+        int     imageIdx            = 0;
+        int     counterImages       = 0;
+        std::vector<double> cycleTime;
+
+        double  now                 = yarp::os::Time::now();
+        start = now;
+        while(!isStopping())
+        {
+            if(-1 == ::write(fd, img[imageIdx]->imageData, img[imageIdx]->imageSize) )
+                yError() << "Failed setting image to display";
+
+            imageIdx++;
+            if(imageIdx >= 10)
+                imageIdx = 0;
+
+            now = yarp::os::Time::now();
+            elapsedTime = now - last;
+            cycleTime.push_back(elapsedTime);
+
+//             yDebug() << "counterImages: "   << counterImages << " now " << now << "last" << last << "elapsedTime" << elapsedTime
+//                                                              << "start" << start << "diff" << start-now;
+
+            counterImages++;
+            // report images x sec
+            if(now-start > 1.0f)
+            {
+                double max=0, min=cycleTime[0], mean=0, sum_deviation=0;
+
+                for(int i=0; i<cycleTime.size(); i++)
+                {
+                    mean += cycleTime[i];
+                    if(cycleTime[i] > max)
+                        max = cycleTime[i];
+
+                    if(cycleTime[i] < min)
+                        min = cycleTime[i];
+                }
+                mean=mean/cycleTime.size();
+
+                for(int i=0; i<cycleTime.size(); i++)
+                {
+                    sum_deviation += (cycleTime[i]-mean)*(cycleTime[i]-mean);
+                }
+
+                sum_deviation = sqrt(sum_deviation / cycleTime.size());
+
+                yInfo() << "Images per secs: " << counterImages;
+                yInfo() << "Time to write an image: Max " << max << " Min " << min;
+                yInfo() << "Mean " << mean << " deviation " << sum_deviation;
+
+                counterImages = 0;
+                cycleTime.clear();
+                now  = yarp::os::Time::now();
+                start = now;
+            }
+            last = now;
+        }
+        return;
+    }
+
+
+    if(selfTest == 2)
+    {
+        cv::Mat img(IMAGE_HEIGHT,IMAGE_WIDTH, CV_8UC3, cv::Scalar(0,0,0));
+        cv::Mat black(IMAGE_HEIGHT,IMAGE_WIDTH, CV_8UC3, cv::Scalar(0,0,0));
+
+        cout << "elemSize " << img.elemSize() << endl;
+        cout << "total " << img.total() << endl;
+
+        unsigned long int counter = 0;
+
+        bool toggleColor = false;
+
+        cv::Vec3b color;
+        switch(color_choise)
+        {
+            case 0:
+                color[0] = 255;
+                color[1] = 0;
+                color[2] = 0;
+                break;
+
+            case 1:
+                color[0] = 0;
+                color[1] = 255;
+                color[2] = 0;
+                break;
+
+            case 2:
+                color[0] = 0;
+                color[1] = 0;
+                color[2] = 255;
+                break;
+
+        }
+        cv::Vec3b color_white( 0,  255, 0);
+        cv::Vec3b color_black( 0, 0, 0);
+
+        ::write(fd, black.data, black.total()*3);
+
+        while(!isStopping())
+        {
+            for(int row=0; (row< img.rows) && (!isStopping()); row++)
+            {
+                for(int col=16*4; (col<img.cols) && (!isStopping()); col++)
+                {
+                    if(toggleColor)
+                        img.at<cv::Vec3b>(row,col) = color_black;
+                    else
+                        img.at<cv::Vec3b>(row,col) = color;
+
+                    if(-1 == ::write(fd, img.data, img.total()*3) )
+                        yError() << "Failed setting image to display";
+                }
+            }
+            toggleColor = !toggleColor;
+        }
+        cout << "thread quittting" << endl;
+        return;
+    }
+
+
+
+    if(selfTest == 3)
+    {
+        bool toggleImage = false;
+        cv::Mat image_1  = cv::imread(yarp::os::ConstString(rootPath + "/fra.bmp").c_str(), CV_LOAD_IMAGE_COLOR);
+        cv::Mat image_2  = cv::imread(yarp::os::ConstString(rootPath + "/homer.bmp").c_str(), CV_LOAD_IMAGE_COLOR);
+
+        cv::Mat image_tmp   = cv::imread(yarp::os::ConstString(rootPath + "/homer.bmp").c_str(), CV_LOAD_IMAGE_COLOR);
+
+
+        cv::cvtColor(image_1,image_1,CV_BGR2RGB);
+        cv::cvtColor(image_2,image_2,CV_BGR2RGB);
+
+        cv::Mat *image_init, *image_final;
+
+        image_init  = &image_1;
+        image_final = &image_2;
+
+        if(-1 == ::write(fd, image_1.data, image_1.total()*3) )
+            yError() << "Failed setting image to display";
+        yarp::os::Time::delay(2);
+
+        int step = 0;
+        while(!isStopping())
+        {
+            for(int row=0; (row<image_tmp.rows) && (!isStopping()); row++)
+            {
+                for(int col=16*4; (col<image_tmp.cols) && (!isStopping()); col++)
+                {
+                    image_tmp.at<cv::Vec3b>(row,col)[0] = ((double) (image_final->at<cv::Vec3b>(row,col)[0] - image_init->at<cv::Vec3b>(row,col)[0]) * step/steps) + image_init->at<cv::Vec3b>(row,col)[0];
+                    image_tmp.at<cv::Vec3b>(row,col)[1] = ((double) (image_final->at<cv::Vec3b>(row,col)[1] - image_init->at<cv::Vec3b>(row,col)[1]) * step/steps) + image_init->at<cv::Vec3b>(row,col)[1];
+                    image_tmp.at<cv::Vec3b>(row,col)[2] = ((double) (image_final->at<cv::Vec3b>(row,col)[2] - image_init->at<cv::Vec3b>(row,col)[2]) * step/steps) + image_init->at<cv::Vec3b>(row,col)[2];
+                }
+            }
+
+            if(-1 == ::write(fd, image_tmp.data, image_tmp.total()*3) )
+                yError() << "Failed setting image to display";
+
+            step++;
+
+            if(step >= steps)
+            {
+                toggleImage = !toggleImage;
+
+                if(toggleImage)
+                {
+                    image_init  = &image_2;
+                    image_final = &image_1;
+                }
+                else
+                {
+                    image_init  = &image_1;
+                    image_final = &image_2;
+                }
+                step = 0;
+                yarp::os::Time::delay(2);
+            }
+        }
+    }
+
+
+    // normal workflow
     while(!isStopping())
     {
         IplImage* img;
-        yTrace() << "... waiting for commands";
+        yTrace() << "\n\t... waiting for commands";
         if(!rpcPort.read(command))
             continue;
 
@@ -269,7 +530,7 @@ bool FaceDisplayServer::close()
         Thread::stop();
     }
     Thread::stop();
-    detachAll();
+    cout << "Closing fd" << endl;
     ::close(fd);
     return true;
 }

--- a/cermod/faceDisplayServer/faceDisplayServer.h
+++ b/cermod/faceDisplayServer/faceDisplayServer.h
@@ -167,6 +167,13 @@ private:
     int                     color_choise;
     yarp::os::Semaphore     mutex;
 
+    // for timing measurement
+    double                  _now, _last, _elapsedTime, _start;
+    int                     imageIdx;
+    int                     counterImages;
+    std::vector<double>     cycleTime;
+    void measureTiming();
+
 #endif //DOXYGEN_SHOULD_SKIP_THIS
 };
 

--- a/cermod/faceDisplayServer/faceDisplayServer.h
+++ b/cermod/faceDisplayServer/faceDisplayServer.h
@@ -92,9 +92,10 @@ typedef struct auxdisp_regs {
  * \endcode
  */
 
+};
+
 class cer::dev::FaceDisplayServer:  public yarp::os::Thread,
-                                    public yarp::dev::DeviceDriver,
-                                    public yarp::dev::IMultipleWrapper
+                                    public yarp::dev::DeviceDriver
 {
 public:
     // Constructor used by yarp factory
@@ -109,14 +110,7 @@ public:
     void setId(const std::string &id);
     std::string getId();
 
-    /**
-      * Specify which analog sensor this thread has to read from.
-      */
-    bool attachAll(const yarp::dev::PolyDriverList &p);
-    bool detachAll();
-
     void onStop();
-
     void run();
 
 private:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,4 +39,5 @@ set(CMAKE_SHARED_MODULE_PREFIX "")
 
 # Build camera tests
 # add_subdirectory(src/tripod)
+add_subdirectory(src/displayTest)
 

--- a/tests/src/displayTest/CMakeLists.txt
+++ b/tests/src/displayTest/CMakeLists.txt
@@ -1,0 +1,37 @@
+
+#  Copyright (C) 2016 iCub Facility - Istituto Italiano di Tecnologia
+#  Authors: Alberto Cardellino <alberto.cardellino@iit.it>
+#
+#  Copy Policy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+#
+
+cmake_minimum_required(VERSION 2.8.9)
+
+# set the project name
+set(TESTNAME displayTest)
+
+# add the required cmake packages
+find_package(RTF COMPONENTS DLL)
+find_package(YARP REQUIRED)
+
+# add include directories
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}
+                    ${RTF_INCLUDE_DIRS}
+                    ${YARP_INCLUDE_DIRS}
+                    ${YARP_HELPERS_INCLUDE_DIR}
+                    ${OPENCV_INCLUDE_DIR})
+
+include_directories(${FaceDisplayServer_SOURCE_DIR})
+
+# add the source codes to build the plugin library
+add_library(${TESTNAME} MODULE displayTest.h  displayTest.cpp)
+
+# add required libraries
+target_link_libraries(${TESTNAME} ${RTF_LIBRARIES} ${YARP_LIBRARIES} ${OpenCV_LIBRARIES})
+
+# set the installation options
+install(TARGETS ${TESTNAME}
+        EXPORT ${TESTNAME}
+        COMPONENT runtime
+        LIBRARY DESTINATION lib)
+

--- a/tests/src/displayTest/displayTest.cpp
+++ b/tests/src/displayTest/displayTest.cpp
@@ -1,0 +1,117 @@
+
+//  Copyright (C) 2016 iCub Facility - Istituto Italiano di Tecnologia
+//  Authors: Alberto Cardellino <alberto.cardellino@iit.it>
+//
+//  Copy Policy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+
+
+#include <iostream>
+#include <stdlib.h>
+#include <math.h>
+#include <rtf/TestAssert.h>
+#include <rtf/yarp/YarpTestAsserter.h>
+#include <rtf/dll/Plugin.h>
+#include <yarp/os/Network.h>
+#include <yarp/os/Time.h>
+#include <yarp/os/RFModule.h>
+#include <yarp/os/Property.h>
+#include <yarp/os/LogStream.h>
+
+#include <displayTest.h>
+
+
+using namespace RTF;
+using namespace RTF::YARP;
+using namespace yarp::os;
+using namespace yarp::sig;
+
+
+// prepare the plugin
+PREPARE_PLUGIN(DisplayTest)
+
+
+/**************** Main Test ***********************/
+DisplayTest::DisplayTest() : YarpTestCase("DisplayTest")
+{
+
+}
+
+DisplayTest::~DisplayTest() { }
+
+bool DisplayTest::setup(yarp::os::Property& property)
+{
+    yTrace() << "\nParameters are:\n\t" << property.toString();
+
+    // read param from config file
+    yarp::os::ConstString local  = property.check("local",  yarp::os::Value("/displayTest")).asString();
+    yarp::os::ConstString remote = property.check("remote", yarp::os::Value("/robot/faceDisplay")).asString();
+
+    // initialize device
+    yarp::os::Property prop;
+    prop.put("device", "faceDisplayClient");
+    prop.put("local" , local);
+    prop.put("remote", remote);
+
+    if(!display.open(prop))
+    {
+        yError() << "Cannot connect to display device";
+        return false;
+    }
+
+    // Check interfaces
+    display.view(iDisp);
+
+    RTF_ASSERT_ERROR_IF( !(!iDisp),  Asserter::format("Cannot get the required interface"));
+
+    return true;
+}
+
+void DisplayTest::run()
+{
+    yTrace();
+
+    double wait = 1;
+    yarp::os::Time::delay(wait);
+    iDisp->setFaceExpression(VOCAB_FACE_HAPPY);
+    yarp::os::Time::delay(wait);
+    iDisp->setFaceExpression(VOCAB_FACE_SAD);
+    yarp::os::Time::delay(wait);
+    iDisp->setFaceExpression(VOCAB_FACE_WARNING);
+
+    yarp::os::Time::delay(wait);
+    iDisp->setImageFile("homer.bmp");
+    yarp::os::Time::delay(wait);
+    iDisp->setImageFile("balette.bmp");
+    yarp::os::Time::delay(wait);
+    iDisp->setImageFile("RobotE_PNG_80x32_16bit_01.bmp");
+
+
+    // Creating an image to send
+    yarp::sig::ImageOf<yarp::sig::PixelRgb> imgTest;
+
+    imgTest.resize(80, 32);
+
+    unsigned char *p;
+    for(int base=0; base<80; base++)
+    {
+        p = imgTest.getRawImage();
+        for(int r=0; r<32; r++)
+        {
+            for(int c=0; c<80; c++)
+            {
+                *p = (unsigned char) (base+r*8)%255;  p++;
+                *p = (unsigned char) (base+c*3)%255;  p++;
+                *p = (unsigned char)     base  %255;  p++;
+            }
+        }
+        iDisp->setImage(imgTest);
+        yarp::os::Time::delay(0.03);
+    }
+}
+
+void DisplayTest::tearDown()
+{
+    yTrace();
+    display.close();
+    iDisp = NULL;
+}

--- a/tests/src/displayTest/displayTest.h
+++ b/tests/src/displayTest/displayTest.h
@@ -1,0 +1,48 @@
+
+//  Copyright (C) 2016 iCub Facility - Istituto Italiano di Tecnologia
+//  Authors: Alberto Cardellino <alberto.cardellino@iit.it>
+//
+//  Copy Policy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+
+
+#ifndef DISPLAY_TEST_H
+#define DISPLAY_TEST_H
+
+#include <yarp/sig/Image.h>
+#include <yarp/os/RateThread.h>
+#include <yarp/dev/PolyDriver.h>
+#include <yarp/os/BufferedPort.h>
+
+#include <IFaceDisplayInterface.h>
+
+#include <rtf/yarp/YarpTestCase.h>
+
+/**
+* \ingroup cer-tests
+* Test basic functionalities of CER display device
+*
+*  Accepts the following parameters:
+* | Parameter name | Type   | Units | Default Value      | Required | Description                                        | Notes |
+* |:--------------:|:------:|:-----:|:------------------:|:--------:|:--------------------------------------------------:|:-----:|
+* | local          | string | -     | /displayTest       | No       | The prefix name of the local ports to open.        | -     |
+* | remote         | string | -     | /robot/faceDisplay | No       | The prefix name of the remote ports to connect to. | -     |
+*/
+
+class DisplayTest : public YarpTestCase
+{
+public:
+    DisplayTest();
+    virtual ~DisplayTest();
+
+    virtual bool setup(yarp::os::Property& property);
+    virtual void run();
+    virtual void tearDown();
+
+private:
+    yarp::sig::Image                image;
+    yarp::dev::PolyDriver           display;
+    cer::dev::IFaceDisplay          *iDisp;
+
+};
+
+#endif //DISPLAY_TEST_H


### PR DESCRIPTION
This PR introduces some improvement for faceDisplay client & server and a new testCase for display.
- new port for yarp::sig::image: you can remotely set the image you want to be displayed on the robot. Format, must be 80*32 pixel rgb
- vocab interface similar to iCub's faceExpression
- command line interface supported. e.g. 
  
  `yarp write ... /robot/faceDisplay/rpc`
  `set face hap`
- server has 3 `selfTest`, they can be run with `yarpdev --device faceDisplayServer --selfTest N` with N equal to 1, 2 or 3
  <a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
  <a href='https://www.codereviewhub.com/robotology/cer/pull/16?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/cer/pull/16'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
  <a href='#crh-end'></a>
