### PR TITLE
IpOpt dependant modules

### DIFF
--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -2,8 +2,11 @@
 # Author: Ugo Pattacini
 # email:  ugo.pattacini@iit.it
 
-add_subdirectory(reaching)
-add_subdirectory(gaze-controller)
+if(IPOPT_FOUND)
+    add_subdirectory(reaching)
+    add_subdirectory(gaze-controller)
+endif()
+
 add_subdirectory(teleop)
 add_subdirectory(tripodJoystickControl)
 add_subdirectory(robotJoystickControl)


### PR DESCRIPTION
The reason is that on the r1-torso robot ipopt is not installed, but other modules are required.

@pattacini Am I missing some modules?