### PR TITLE
Prevent shoulder from hitting torso's cover

### DIFF
--- a/libraries/cer_kinematics/include/cer_kinematics/private/arm_common.h
+++ b/libraries/cer_kinematics/include/cer_kinematics/private/arm_common.h
@@ -51,6 +51,8 @@ protected:
     Matrix H,H_,J_,T;
     Vector q;
 
+    Vector cover_shoulder_avoidance;
+
     /****************************************************************/
     TripodState tripod_fkin(const int which, const Ipopt::Number *x,
                             TripodState *internal=NULL)
@@ -140,6 +142,14 @@ public:
         x=x0;
         set_target(eye(4,4));
         q=x0.subVector(3,3+upper_arm.getDOF()-1);
+
+        // limits to prevent shoulder from hitting torso's cover
+        double roll_0=CTRL_DEG2RAD*5.0;  double pitch_0=CTRL_DEG2RAD*0.0;   // [rad]
+        double roll_1=CTRL_DEG2RAD*15.0; double pitch_1=CTRL_DEG2RAD*60.0;  // [rad]
+
+        cover_shoulder_avoidance.resize(2);
+        cover_shoulder_avoidance[0]=(roll_1-roll_0)/(pitch_1-pitch_0);
+        cover_shoulder_avoidance[1]=roll_0;
     }
 
     /****************************************************************/

--- a/libraries/cer_kinematics/include/cer_kinematics/private/arm_full_notorso_heave.h
+++ b/libraries/cer_kinematics/include/cer_kinematics/private/arm_full_notorso_heave.h
@@ -37,8 +37,8 @@ public:
                       Ipopt::Index &nnz_h_lag, IndexStyleEnum &index_style)
     {
         n=x0.length();
-        m=1+1;
-        nnz_jac_g=3+(n-4);
+        m=1+1+1;
+        nnz_jac_g=3+(n-4)+2;
         nnz_h_lag=0;
         index_style=TNLP::C_STYLE;
 
@@ -73,6 +73,7 @@ public:
 
         g_l[0]=lower_arm.cos_alpha_max; g_u[0]=1.0;
         g_l[1]=g_u[1]=0.0;
+        g_l[2]=cover_shoulder_avoidance[1]; g_u[2]=std::numeric_limits<double>::max();
 
         latch_idx.clear();
         latch_gl.clear();
@@ -93,6 +94,7 @@ public:
 
         g[0]=din2.n[2];
         g[1]=norm2(xd-T.getCol(3).subVector(0,2));
+        g[2]=-cover_shoulder_avoidance[0]*x[4]+x[5];
 
         latch_x_verifying_alpha(n,x,g);
 
@@ -111,13 +113,17 @@ public:
             iRow[1]=0; jCol[1]=10;
             iRow[2]=0; jCol[2]=11;
 
-            // g[1]
+            // g[1] (reaching position)
             Ipopt::Index idx=3;
             for (Ipopt::Index col=4; col<n; col++)
             {
                 iRow[idx]=1; jCol[idx]=col;
                 idx++;
             }
+
+            // g[2] (cover constraints)
+            iRow[11]=2; jCol[11]=4;
+            iRow[12]=2; jCol[12]=5;
         }
         else
         {
@@ -174,6 +180,10 @@ public:
             e_fw=xd-(M*d_fw.T*TN).getCol(3).subVector(0,2);
             values[10]=2.0*dot(e,e_fw-e)/drho;
             x_dx[11]=x[11];
+
+            // g[2]
+            values[11]=-cover_shoulder_avoidance[0];
+            values[12]=1.0;
         }
 
         return true;
@@ -202,8 +212,8 @@ public:
                       Ipopt::Index &nnz_h_lag, IndexStyleEnum &index_style)
     {
         n=x0.length();
-        m=1+1;
-        nnz_jac_g=3+(n-4);
+        m=1+1+1;
+        nnz_jac_g=3+(n-4)+2;
         nnz_h_lag=0;
         index_style=TNLP::C_STYLE;
 
@@ -238,6 +248,7 @@ public:
 
         g_l[0]=lower_arm.cos_alpha_max; g_u[0]=1.0;
         g_l[1]=g_u[1]=0.0;
+        g_l[2]=cover_shoulder_avoidance[1]; g_u[2]=std::numeric_limits<double>::max();
 
         latch_idx.clear();
         latch_gl.clear();
@@ -258,6 +269,7 @@ public:
 
         g[0]=din2.n[2];
         g[1]=norm2(xd-T.getCol(3).subVector(0,2));
+        g[2]=-cover_shoulder_avoidance[0]*x[4]+x[5];
 
         latch_x_verifying_alpha(n,x,g);
 
@@ -276,13 +288,17 @@ public:
             iRow[1]=0; jCol[1]=10;
             iRow[2]=0; jCol[2]=11;
 
-            // g[1]
+            // g[1] (reaching position)
             Ipopt::Index idx=3;
             for (Ipopt::Index col=4; col<n; col++)
             {
                 iRow[idx]=1; jCol[idx]=col;
                 idx++;
             }
+
+            // g[2] (cover constraints)
+            iRow[11]=2; jCol[11]=4;
+            iRow[12]=2; jCol[12]=5;
         }
         else
         {
@@ -354,6 +370,10 @@ public:
             e_bw=xd-(M*d_bw.T*TN).getCol(3).subVector(0,2);
             values[10]=dot(e,e_fw-e_bw)/drho;
             x_dx[11]=x[11];
+
+            // g[2]
+            values[11]=-cover_shoulder_avoidance[0];
+            values[12]=1.0;
         }
 
         return true;

--- a/libraries/cer_kinematics/include/cer_kinematics/private/arm_xyz_heave.h
+++ b/libraries/cer_kinematics/include/cer_kinematics/private/arm_xyz_heave.h
@@ -36,8 +36,8 @@ public:
                       Ipopt::Index &nnz_h_lag, IndexStyleEnum &index_style)
     {
         n=x0.length();
-        m=1+1;
-        nnz_jac_g=3+3;
+        m=1+1+1;
+        nnz_jac_g=3+3+2;
         nnz_h_lag=0;
         index_style=TNLP::C_STYLE;
 
@@ -72,8 +72,9 @@ public:
             x_u[offs+i]=lower_arm.l_max;
         }
 
-        g_l[0]=torso.cos_alpha_max;     g_u[0]=1.0;
-        g_l[1]=lower_arm.cos_alpha_max; g_u[1]=1.0;
+        g_l[0]=torso.cos_alpha_max;         g_u[0]=1.0;
+        g_l[1]=lower_arm.cos_alpha_max;     g_u[1]=1.0;
+        g_l[2]=cover_shoulder_avoidance[1]; g_u[2]=std::numeric_limits<double>::max();
 
         latch_idx.clear();
         latch_gl.clear();
@@ -97,6 +98,7 @@ public:
         computeQuantities(x,new_x);
         g[0]=din1.n[2];
         g[1]=din2.n[2];
+        g[2]=-cover_shoulder_avoidance[0]*x[4]+x[5];
 
         latch_x_verifying_alpha(n,x,g);
 
@@ -119,6 +121,10 @@ public:
             iRow[3]=1; jCol[3]=9;
             iRow[4]=1; jCol[4]=10;
             iRow[5]=1; jCol[5]=11;
+
+            // g[2] (cover constraints)
+            iRow[6]=2; jCol[6]=4;
+            iRow[7]=2; jCol[7]=5;
         }
         else
         {
@@ -161,6 +167,10 @@ public:
             tripod_fkin(2,x_dx,&d_fw);
             values[5]=(d_fw.n[2]-din2.n[2])/drho;
             x_dx[11]=x[11];
+
+            // g[2]
+            values[6]=-cover_shoulder_avoidance[0];
+            values[7]=1.0;
         }
 
         return true;
@@ -188,8 +198,8 @@ public:
                       Ipopt::Index &nnz_h_lag, IndexStyleEnum &index_style)
     {
         n=x0.length();
-        m=1+1;
-        nnz_jac_g=3+3;
+        m=1+1+1;
+        nnz_jac_g=3+3+2;
         nnz_h_lag=0;
         index_style=TNLP::C_STYLE;
 
@@ -224,8 +234,9 @@ public:
             x_u[offs+i]=lower_arm.l_max;
         }
 
-        g_l[0]=torso.cos_alpha_max;     g_u[0]=1.0;
-        g_l[1]=lower_arm.cos_alpha_max; g_u[1]=1.0;
+        g_l[0]=torso.cos_alpha_max;         g_u[0]=1.0;
+        g_l[1]=lower_arm.cos_alpha_max;     g_u[1]=1.0;
+        g_l[2]=cover_shoulder_avoidance[1]; g_u[2]=std::numeric_limits<double>::max();
 
         latch_idx.clear();
         latch_gl.clear();
@@ -249,6 +260,7 @@ public:
         computeQuantities(x,new_x);
         g[0]=din1.n[2];
         g[1]=din2.n[2];
+        g[2]=-cover_shoulder_avoidance[0]*x[4]+x[5];
 
         latch_x_verifying_alpha(n,x,g);
 
@@ -271,6 +283,10 @@ public:
             iRow[3]=1; jCol[3]=9;
             iRow[4]=1; jCol[4]=10;
             iRow[5]=1; jCol[5]=11;
+
+            // g[2] (cover constraints)
+            iRow[6]=2; jCol[6]=4;
+            iRow[7]=2; jCol[7]=5;
         }
         else
         {
@@ -325,6 +341,10 @@ public:
             tripod_fkin(2,x_dx,&d_bw);
             values[5]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[11]=x[11];
+
+            // g[2]
+            values[6]=-cover_shoulder_avoidance[0];
+            values[7]=1.0;
         }
 
         return true;

--- a/libraries/cer_kinematics/include/cer_kinematics/private/arm_xyz_noheave.h
+++ b/libraries/cer_kinematics/include/cer_kinematics/private/arm_xyz_noheave.h
@@ -36,8 +36,8 @@ public:
                       Ipopt::Index &nnz_h_lag, IndexStyleEnum &index_style)
     {
         n=x0.length();
-        m=2+2;
-        nnz_jac_g=6+6;
+        m=2+2+1;
+        nnz_jac_g=6+6+2;
         nnz_h_lag=0;
         index_style=TNLP::C_STYLE;
 
@@ -77,6 +77,8 @@ public:
 
         g_l[2]=g_u[2]=0.0;
         g_l[3]=lower_arm.cos_alpha_max; g_u[3]=1.0;
+
+        g_l[4]=cover_shoulder_avoidance[1]; g_u[4]=std::numeric_limits<double>::max();
 
         latch_idx.clear();
         latch_gl.clear();
@@ -223,6 +225,8 @@ public:
         g[2]=e2*e2;
         g[3]=din2.n[2];
 
+        g[4]=-cover_shoulder_avoidance[0]*x[4]+x[5];
+
         latch_x_verifying_alpha(n,x,g);
 
         return true;
@@ -254,6 +258,10 @@ public:
             iRow[9]=3;  jCol[9]=9;
             iRow[10]=3; jCol[10]=10;
             iRow[11]=3; jCol[11]=11;
+
+            // g[4] (cover constraints)
+            iRow[12]=4; jCol[12]=4;
+            iRow[13]=4; jCol[13]=5;
         }
         else
         {
@@ -306,6 +314,10 @@ public:
             values[8]=-2.0*e2*(d_fw.p[2]-din2.p[2])/drho;
             values[11]=(d_fw.n[2]-din2.n[2])/drho;
             x_dx[11]=x[11];
+
+            // g[4]
+            values[12]=-cover_shoulder_avoidance[0];
+            values[13]=1.0;
         }
 
         return true;
@@ -439,6 +451,10 @@ public:
             iRow[9]=3;  jCol[9]=9;
             iRow[10]=3; jCol[10]=10;
             iRow[11]=3; jCol[11]=11;
+
+            // g[4] (cover constraints)
+            iRow[12]=4; jCol[12]=4;
+            iRow[13]=4; jCol[13]=5;
         }
         else
         {
@@ -503,6 +519,10 @@ public:
             values[8]=-e2*(d_fw.p[2]-d_bw.p[2])/drho;
             values[11]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[11]=x[11];
+
+            // g[4]
+            values[12]=-cover_shoulder_avoidance[0];
+            values[13]=1.0;
         }
 
         return true;

--- a/libraries/cer_kinematics/include/cer_kinematics/private/arm_xyz_notorso_heave.h
+++ b/libraries/cer_kinematics/include/cer_kinematics/private/arm_xyz_notorso_heave.h
@@ -37,8 +37,8 @@ public:
                       Ipopt::Index &nnz_h_lag, IndexStyleEnum &index_style)
     {
         n=x0.length();
-        m=1;
-        nnz_jac_g=3;
+        m=1+1;
+        nnz_jac_g=3+2;
         nnz_h_lag=0;
         index_style=TNLP::C_STYLE;
 
@@ -75,7 +75,8 @@ public:
         latch_gl.clear();
         latch_gu.clear();
 
-        g_l[0]=lower_arm.cos_alpha_max; g_u[0]=1.0;
+        g_l[0]=lower_arm.cos_alpha_max;     g_u[0]=1.0;
+        g_l[1]=cover_shoulder_avoidance[1]; g_u[1]=std::numeric_limits<double>::max();
 
         latch_idx.push_back(0);
         latch_gl.push_back(g_l[0]);
@@ -91,6 +92,8 @@ public:
         computeQuantities(x,new_x);
 
         g[0]=din2.n[2];
+        g[1]=-cover_shoulder_avoidance[0]*x[4]+x[5];
+
         latch_x_verifying_alpha(n,x,g);
 
         return true;
@@ -107,6 +110,10 @@ public:
             iRow[0]=0; jCol[0]=9;
             iRow[1]=0; jCol[1]=10;
             iRow[2]=0; jCol[2]=11;
+
+            // g[1] (cover constraints)
+            iRow[3]=1; jCol[3]=4;
+            iRow[4]=1; jCol[4]=5;
         }
         else
         {
@@ -133,6 +140,10 @@ public:
             tripod_fkin(2,x_dx,&d_fw);
             values[2]=(d_fw.n[2]-din2.n[2])/drho;
             x_dx[11]=x[11];
+
+            // g[1]
+            values[3]=-cover_shoulder_avoidance[0];
+            values[4]=1.0;
         }
 
         return true;
@@ -161,8 +172,8 @@ public:
                       Ipopt::Index &nnz_h_lag, IndexStyleEnum &index_style)
     {
         n=x0.length();
-        m=1;
-        nnz_jac_g=3;
+        m=1+1;
+        nnz_jac_g=3+2;
         nnz_h_lag=0;
         index_style=TNLP::C_STYLE;
 
@@ -199,7 +210,8 @@ public:
         latch_gl.clear();
         latch_gu.clear();
 
-        g_l[0]=lower_arm.cos_alpha_max; g_u[0]=1.0;
+        g_l[0]=lower_arm.cos_alpha_max;     g_u[0]=1.0;
+        g_l[1]=cover_shoulder_avoidance[1]; g_u[1]=std::numeric_limits<double>::max();
 
         latch_idx.push_back(0);
         latch_gl.push_back(g_l[0]);
@@ -215,6 +227,8 @@ public:
         computeQuantities(x,new_x);
 
         g[0]=din2.n[2];
+        g[1]=-cover_shoulder_avoidance[0]*x[4]+x[5];
+
         latch_x_verifying_alpha(n,x,g);
 
         return true;
@@ -231,6 +245,10 @@ public:
             iRow[0]=0; jCol[0]=9;
             iRow[1]=0; jCol[1]=10;
             iRow[2]=0; jCol[2]=11;
+
+            // g[1] (cover constraints)
+            iRow[3]=1; jCol[3]=4;
+            iRow[4]=1; jCol[4]=5;
         }
         else
         {
@@ -265,6 +283,10 @@ public:
             tripod_fkin(2,x_dx,&d_bw);
             values[2]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[11]=x[11];
+
+            // g[1]
+            values[3]=-cover_shoulder_avoidance[0];
+            values[4]=1.0;
         }
 
         return true;

--- a/libraries/cer_kinematics/include/cer_kinematics/private/arm_xyz_notorso_noheave.h
+++ b/libraries/cer_kinematics/include/cer_kinematics/private/arm_xyz_notorso_noheave.h
@@ -36,8 +36,8 @@ public:
                       Ipopt::Index &nnz_h_lag, IndexStyleEnum &index_style)
     {
         n=x0.length();
-        m=2;
-        nnz_jac_g=6;
+        m=2+1;
+        nnz_jac_g=6+2;
         nnz_h_lag=0;
         index_style=TNLP::C_STYLE;
 
@@ -75,7 +75,8 @@ public:
         latch_gu.clear();
 
         g_l[0]=g_u[0]=0.0;
-        g_l[1]=lower_arm.cos_alpha_max; g_u[1]=1.0;
+        g_l[1]=lower_arm.cos_alpha_max;     g_u[1]=1.0;
+        g_l[2]=cover_shoulder_avoidance[1]; g_u[2]=std::numeric_limits<double>::max();
 
         latch_idx.push_back(1);
         latch_gl.push_back(g_l[1]);
@@ -176,6 +177,7 @@ public:
         double e2=hd2-din2.p[2];
         g[0]=e2*e2;
         g[1]=din2.n[2];
+        g[2]=-cover_shoulder_avoidance[0]*x[4]+x[5];
 
         latch_x_verifying_alpha(n,x,g);
 
@@ -198,6 +200,10 @@ public:
             iRow[3]=1; jCol[3]=9;
             iRow[4]=1; jCol[4]=10;
             iRow[5]=1; jCol[5]=11;
+
+            // g[2] (cover constraints)
+            iRow[6]=2; jCol[6]=4;
+            iRow[7]=2; jCol[7]=5;
         }
         else
         {
@@ -229,6 +235,10 @@ public:
             values[2]=-2.0*e2*(d_fw.p[2]-din2.p[2])/drho;
             values[5]=(d_fw.n[2]-din2.n[2])/drho;
             x_dx[11]=x[11];
+
+            // g[2]
+            values[6]=-cover_shoulder_avoidance[0];
+            values[7]=1.0;
         }
 
         return true;
@@ -326,6 +336,10 @@ public:
             iRow[3]=1; jCol[3]=9;
             iRow[4]=1; jCol[4]=10;
             iRow[5]=1; jCol[5]=11;
+
+            // g[2] (cover constraints)
+            iRow[6]=2; jCol[6]=4;
+            iRow[7]=2; jCol[7]=5;
         }
         else
         {
@@ -363,6 +377,10 @@ public:
             values[2]=-e2*(d_fw.p[2]-d_bw.p[2])/drho;
             values[5]=(d_fw.n[2]-d_bw.n[2])/(2.0*drho);
             x_dx[11]=x[11];
+
+            // g[2]
+            values[6]=-cover_shoulder_avoidance[0];
+            values[7]=1.0;
         }
 
         return true;


### PR DESCRIPTION
This PR performs reaching while preventing the shoulder from hitting the torso's cover.

The implementation resorts to a further linear constraint relating the movements of the shoulder's pitch and roll.

cc @randaz81 @aerydna 