### PR TITLE
[faceExpression] added talking mouth

### DIFF
--- a/modules/faceExpression/faceExpressionImage.hpp
+++ b/modules/faceExpression/faceExpressionImage.hpp
@@ -15,6 +15,8 @@
 
 #define VOCAB_AUDIO_START       VOCAB4('a','s','t','a')
 #define VOCAB_AUDIO_STOP        VOCAB4('a','s','t','o')
+#define VOCAB_TALK_START        VOCAB4('t','s','t','a')
+#define VOCAB_TALK_STOP         VOCAB4('t','s','t','o')
 #define VOCAB_BLINK             VOCAB4('b','l','i','n')
 #define VOCAB_RESET             VOCAB3('r','s','t')
 
@@ -61,12 +63,15 @@ public:
 
     void activateBlink(bool activate);
     void activateBars (bool activate);
+    void activateTalk (bool activate);
 
     bool updateBars(float percentage);
     bool updateBlink(int index);
+    cv::Mat updateTalk();
 
     bool doBlink;
     bool doBars;
+    bool doTalk;
 
 private:
     yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelRgb> >  &port;


### PR DESCRIPTION
This PR introduces the so-called _talking mouth_ modality. See the video below (wait until the GIF gets entirely loaded to play it smoothly).

### How-to guide to enable/disable talking
```sh
$ yarp rpc /faceExpressionImage/rpc
>> [tstart]
>> [tstop]
```
These commands resemble somehow `[astart]` & `[astop]` that are used to start/stop listening audio sources.

cc @vtikha 

---

![ezgif com-resize](https://user-images.githubusercontent.com/3738070/39620556-dddc5300-4f8b-11e8-9f4c-324f484e8a13.gif)
