### PR TITLE
GazeboTripod: added implementation of getEncoderSpeeds/Accelerations

### DIFF
--- a/gazeboYarpPlugin/GazeboTripod_Implementation.cpp
+++ b/gazeboYarpPlugin/GazeboTripod_Implementation.cpp
@@ -105,21 +105,31 @@ bool GazeboTripodMotionControl::getEncoderSpeed(int j, double* sp)
 
 bool GazeboTripodMotionControl::getEncoderSpeeds(double* spds)
 {
-//     return NOT_YET_IMPLEMENTED("getEncoderSpeeds");
-    return false;
+    if(nullptr == spds) return false;
+
+    for(int i=0; i< m_numberOfJoints; i++)
+        spds[i] = std::nan("");
+    return true;
 }
 
 
-bool GazeboTripodMotionControl::getEncoderAcceleration(int j, double* spds)
+bool GazeboTripodMotionControl::getEncoderAcceleration(int j, double* acc)
 {
-//     return NOT_YET_IMPLEMENTED("getEncoderAcceleration");
+    if (acc && j >= 0 && j < (int)m_numberOfJoints) {
+        *acc = std::nan("");
+        return true;
+    }
     return false;
 }
 
 bool GazeboTripodMotionControl::getEncoderAccelerations(double* accs)
 {
-//     return NOT_YET_IMPLEMENTED("getEncoderAccelerations");
-    return false;
+    if(nullptr == accs) return false;
+
+    for(int i=0; i< m_numberOfJoints; i++)
+        accs[i] = std::nan("");
+    
+    return true;
 }
 
 


### PR DESCRIPTION
Now these functions return true and set speed or acceleration equal to nan.

If a device of motion control returns false the control board wrapper prints error.