### PR TITLE
fixing old inport in tripodMotionControl.h

### DIFF
--- a/cermod/tripod/tripodMotionControl.h
+++ b/cermod/tripod/tripodMotionControl.h
@@ -29,7 +29,7 @@
 #include <yarp/os/Semaphore.h>
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/dev/ControlBoardInterfacesImpl.h>
-#include <yarp/dev/ControlBoardInterfacesImpl.inl>
+#include <yarp/dev/ControlBoardInterfacesImpl-inl.h>
 
 #include <cer_kinematics/tripod.h>
 


### PR DESCRIPTION
This fixed issue #93 .
The PR involves the devel branch only, as the master branch still works with YARP 2.3.64.4

MC