### PR TITLE
Updated gazebo tripod plugin to support version 9 of Gazebo

### DIFF
--- a/gazeboYarpPlugin/GazeboTripodMotionControl.h
+++ b/gazeboYarpPlugin/GazeboTripodMotionControl.h
@@ -37,7 +37,7 @@
 
 #include <boost/shared_ptr.hpp>
 
-#include <gazebo/math/Angle.hh>
+#include <ignition/math/Angle.hh>
 
 namespace cer {
     namespace dev {
@@ -450,7 +450,7 @@ private:
      * \param value Raw value read from Gazebo function like 'GetAngle'
      * \return value in user units
      */
-    double convertGazeboToUser(int joint, gazebo::math::Angle value);
+    double convertGazeboToUser(int joint, ignition::math::Angle value);
     double convertGazeboToUser(int joint, double value);
     double *convertGazeboToUser(double *values);
     double convertGazeboGainToUserGain(int joint, double value);


### PR DESCRIPTION
I updated gazebo tripod plugin using the following migration guide, as @barbalberto suggested me:

https://bitbucket.org/osrf/gazebo/src/default/Migration.md?fileviewer=file-view-default.