### PR TITLE
Make tripod plugin great again

### DIFF
--- a/gazeboYarpPlugin/GazeboTripodMotionControl.cpp
+++ b/gazeboYarpPlugin/GazeboTripodMotionControl.cpp
@@ -70,7 +70,7 @@ bool GazeboTripodMotionControl::tripod_Sim2client(yarp::sig::Vector &sim, yarp::
     client = m_referenceElongations;
     return true;
 #else
-    Vector ypr;
+    Vector ypr(3);
     ypr[0] = 0.0;
     ypr[1] = sim[1];
     ypr[2] = sim[2];

--- a/gazeboYarpPlugin/GazeboTripodMotionControl.cpp
+++ b/gazeboYarpPlugin/GazeboTripodMotionControl.cpp
@@ -66,9 +66,24 @@ bool GazeboTripodMotionControl::tripod_client2Sim(yarp::sig::Vector &client, yar
 
 bool GazeboTripodMotionControl::tripod_Sim2client(yarp::sig::Vector &sim, yarp::sig::Vector &client)
 {
-    // The caller must use mutex or private data
+#ifndef _GAZEBO_PLUGIN_USES_IKIN_
     client = m_referenceElongations;
     return true;
+#else
+    Vector ypr;
+    ypr[0] = 0.0;
+    ypr[1] = sim[1];
+    ypr[2] = sim[2];
+
+    // The caller must use mutex or private data
+    Matrix H = ypr2dcm(ypr);
+    // primo 0, altri 2 sim
+    Vector axis = dcm2axis(H);
+    if(solver.ikin(sim[0], axis, client) )
+        return true;
+    else
+        return false;
+#endif
 }
 
 bool GazeboTripodMotionControl::extractGroup(Bottle &input, Bottle &out, const std::string &key1, const std::string &txt, int size)

--- a/libraries/cer_kinematics/CMakeLists.txt
+++ b/libraries/cer_kinematics/CMakeLists.txt
@@ -24,6 +24,12 @@ set(sources         src/helpers.cpp
                     src/arm.cpp
                     src/head.cpp)
 
+option(GAZEBO_TRIPOD_USES_IKIN "Use iKin to compute tripod simulation" OFF)
+
+if(GAZEBO_TRIPOD_USES_IKIN)
+    add_compile_definitions(_GAZEBO_TRIPOD_USES_IKIN_)
+endif()
+
 source_group("Header Files" FILES ${headers_private} ${headers})
 source_group("Source Files" FILES ${sources})
 


### PR DESCRIPTION
This patch makes the gazebo tripod plugin to use ipopt for inverse kiematic.
It is experimental, so it must be enabled by settng the GAZEBO_TRIPOD_USES_IKIN in the cmake