### PR TITLE
 Firmwareupdater configuration file fix

### DIFF
--- a/app/robots/CER01/CMakeLists.txt
+++ b/app/robots/CER01/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(appname CER01)
 
-set(scripts CER.xml yarprobotinterface.ini general.xml yarpmotorgui.ini)
+set(scripts CER.xml yarprobotinterface.ini general.xml yarpmotorgui.ini firmwareupdater.ini)
 
 yarp_install(FILES ${scripts} DESTINATION ${CER_ROBOTS_INSTALL_DIR}/${appname})
 yarp_install(DIRECTORY calibrators DESTINATION ${CER_ROBOTS_INSTALL_DIR}/${appname})

--- a/app/robots/CER02/CMakeLists.txt
+++ b/app/robots/CER02/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(appname CER02)
 
-set(scripts CER.xml yarprobotinterface.ini general.xml yarpmotorgui.ini)
+set(scripts CER.xml yarprobotinterface.ini general.xml yarpmotorgui.ini firmwareupdater.ini)
 
 yarp_install(FILES ${scripts} DESTINATION ${CER_ROBOTS_INSTALL_DIR}/${appname})
 yarp_install(DIRECTORY calibrators DESTINATION ${CER_ROBOTS_INSTALL_DIR}/${appname})

--- a/app/robots/CER03/CMakeLists.txt
+++ b/app/robots/CER03/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(appname CER03)
 
-set(scripts CER.xml yarprobotinterface.ini general.xml yarpmotorgui.ini)
+set(scripts CER.xml yarprobotinterface.ini general.xml yarpmotorgui.ini firmwareupdater.ini)
 
 yarp_install(FILES ${scripts} DESTINATION ${CER_ROBOTS_INSTALL_DIR}/${appname})
 yarp_install(DIRECTORY calibrators DESTINATION ${CER_ROBOTS_INSTALL_DIR}/${appname})


### PR DESCRIPTION
 In this pr, I updated robots cmake filed, in order to make available firmwareupdater.ini in YARP_DATA_DIRS.
In this way FirmwareUpdater finds its configuration file from any place.
Until now, it was necessary launch FirmwareUpdater from cer/app/robots/CERX folder.

cc @marcoaccame 
