### PR TITLE
Use std::mutex

### DIFF
--- a/cermod/cerDoubleLidar/cerDoubleLidar.cpp
+++ b/cermod/cerDoubleLidar/cerDoubleLidar.cpp
@@ -9,7 +9,6 @@
 #include "cerDoubleLidar.h"
 
 #include <yarp/os/LogStream.h>
-#include <yarp/os/LockGuard.h>
 #include <yarp/os/ResourceFinder.h>
 #include <math.h>
 #include <cmath>
@@ -217,7 +216,7 @@ bool cerDoubleLidar::createLasersDevices(void)
 
 bool cerDoubleLidar::open(yarp::os::Searchable& config)
 {
-    yarp::os::LockGuard guard(m_mutex);
+    std::lock_guard<std::mutex> guard(m_mutex);
     yDebug() << "cerDoubleLidar::open()";
     
     if(!m_lFrontCfg.loadConfig(config))
@@ -330,7 +329,7 @@ bool cerDoubleLidar::verifyLasersConfigurations(void)
 
 bool cerDoubleLidar::getDistanceRange(double& min, double& max)
 {
-    yarp::os::LockGuard guard(m_mutex);
+    std::lock_guard<std::mutex> guard(m_mutex);
     if(!m_inited)
         return false;
     return m_dev_laserFront->getDistanceRange(min, max);
@@ -338,7 +337,7 @@ bool cerDoubleLidar::getDistanceRange(double& min, double& max)
 
 bool cerDoubleLidar::setDistanceRange(double min, double max)
 {
-    yarp::os::LockGuard guard(m_mutex);
+    std::lock_guard<std::mutex> guard(m_mutex);
     if(!m_inited)
         return false;
     double curmin, curmax;
@@ -358,7 +357,7 @@ bool cerDoubleLidar::setDistanceRange(double min, double max)
 
 bool cerDoubleLidar::getScanLimits(double& min, double& max)
 {
-    yarp::os::LockGuard guard(m_mutex);
+    std::lock_guard<std::mutex> guard(m_mutex);
     if(!m_inited)
         return false;
     return m_dev_laserFront->getScanLimits(min, max);
@@ -367,7 +366,7 @@ bool cerDoubleLidar::getScanLimits(double& min, double& max)
 
 bool cerDoubleLidar::setScanLimits(double min, double max)
 {
-    yarp::os::LockGuard guard(m_mutex);
+    std::lock_guard<std::mutex> guard(m_mutex);
     if(!m_inited)
         return false;
 
@@ -388,7 +387,7 @@ bool cerDoubleLidar::setScanLimits(double min, double max)
 
 bool cerDoubleLidar::getHorizontalResolution(double& step)
 {
-    yarp::os::LockGuard guard(m_mutex);
+    std::lock_guard<std::mutex> guard(m_mutex);
     if(!m_inited)
         return false;
     return m_dev_laserFront->getHorizontalResolution(step);
@@ -396,7 +395,7 @@ bool cerDoubleLidar::getHorizontalResolution(double& step)
 
 bool cerDoubleLidar::setHorizontalResolution(double step)
 {
-    yarp::os::LockGuard guard(m_mutex);
+    std::lock_guard<std::mutex> guard(m_mutex);
     if(!m_inited)
         return false;
 
@@ -417,7 +416,7 @@ bool cerDoubleLidar::setHorizontalResolution(double step)
 
 bool cerDoubleLidar::getScanRate(double& rate)
 {
-    yarp::os::LockGuard guard(m_mutex);
+    std::lock_guard<std::mutex> guard(m_mutex);
     if(!m_inited)
         return false;
 
@@ -427,7 +426,7 @@ bool cerDoubleLidar::getScanRate(double& rate)
 
 bool cerDoubleLidar::setScanRate(double rate)
 {
-   yarp::os::LockGuard guard(m_mutex);
+   std::lock_guard<std::mutex> guard(m_mutex);
     if(!m_inited)
         return false;
 
@@ -513,7 +512,7 @@ void cerDoubleLidar::calculate(int sensNum, double distance, int &newSensNum, do
 
 bool cerDoubleLidar::getRawData(yarp::sig::Vector &out)
 {
-    yarp::os::LockGuard guard(m_mutex);
+    std::lock_guard<std::mutex> guard(m_mutex);
 
     if(!m_inited)
     {
@@ -562,7 +561,7 @@ bool cerDoubleLidar::getLaserMeasurement(std::vector<LaserMeasurementData> &data
     return false;
     
     //Some transformation is missing in the following piece of code
-    yarp::os::LockGuard guard(m_mutex);
+    std::lock_guard<std::mutex> guard(m_mutex);
     
     if(!m_inited)
         return false;
@@ -595,7 +594,7 @@ bool cerDoubleLidar::getLaserMeasurement(std::vector<LaserMeasurementData> &data
 
 bool cerDoubleLidar::getDeviceStatus(Device_status &status)
 {
-    yarp::os::LockGuard guard(m_mutex);
+    std::lock_guard<std::mutex> guard(m_mutex);
     if(!m_inited)
         return false;
     Device_status statusFront, statusBack;
@@ -617,7 +616,7 @@ bool cerDoubleLidar::getDeviceStatus(Device_status &status)
 
 bool cerDoubleLidar::getDeviceInfo (std::string &device_info)
 {
-    yarp::os::LockGuard guard(m_mutex);
+    std::lock_guard<std::mutex> guard(m_mutex);
     return true;
 }
 

--- a/cermod/cerDoubleLidar/cerDoubleLidar.h
+++ b/cermod/cerDoubleLidar/cerDoubleLidar.h
@@ -12,21 +12,17 @@
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/sig/Vector.h>
 #include <yarp/os/Time.h>
-#include <yarp/os/Semaphore.h>
 #include <yarp/os/Stamp.h>
 #include <yarp/dev/IRangefinder2D.h>
 #include <yarp/dev/Wrapper.h>
 
 #include <boost/shared_ptr.hpp>
 
-
-
 #include <string>
 #include <functional>
 #include <unordered_map>
 #include <vector>
-
-
+#include <mutex>
 
 namespace cer {
     namespace dev {
@@ -109,12 +105,10 @@ private:
     bool m_inited;
     bool m_onSimulator; //if true the device looks for front and back laser devices in gazebo, else creates them
 
-    
-    yarp::os::Mutex       m_mutex; //MI SERVE??????
+    std::mutex m_mutex; //MI SERVE??????
 
     LaserCfg_t m_lFrontCfg;
     LaserCfg_t m_lBackCfg;
-
 };
 
 #endif //GAZEBOYARP_CONTROLBOARDDRIVER_HH

--- a/cermod/faceDisplayServer/faceDisplayServer.cpp
+++ b/cermod/faceDisplayServer/faceDisplayServer.cpp
@@ -150,10 +150,10 @@ bool FaceDisplayServer::open(yarp::os::Searchable &config)
 
     // clear display
     cv::Mat black(IMAGE_HEIGHT,IMAGE_WIDTH, CV_8UC3, cv::Scalar(0,0,0));
-    mutex.wait();
+    mtx.lock();
     if(-1 == ::write(fd, black.data, black.total()*3) )
         yError() << "Failed setting image to display";
-    mutex.post();
+    mtx.unlock();
     imagePort.init(fd);
 
     // Load all required pieces of image
@@ -472,10 +472,10 @@ void FaceDisplayServer::run()
         {
             for(int offset=0; offset<img->imageSize && !isStopping(); offset+= (imageSize+rowSize))
             {
-                mutex.wait();
+                mtx.lock();
                 if(-1 == ::write(fd, img->imageData+offset, imageSize) )
                     yError() << "Failed setting image to display";
-                mutex.post();
+                mtx.unlock();
                 yarp::os::Time::delay(1.0);
             }
         }
@@ -507,19 +507,19 @@ void FaceDisplayServer::run()
             int centralOffset = 7*imageSize +7*rowSize;
             for(int offset=centralOffset; (offset<img->imageSize) && (!isStopping()); offset+= (imageSize+rowSize))
             {
-                mutex.wait();
+                mtx.lock();
                 if(-1 == ::write(fd, img->imageData+offset, imageSize) )
                     yError() << "Failed setting image to display";
-                mutex.post();
+                mtx.unlock();
                 yarp::os::Time::delay(1.0);
             }
 
             for(int offset=centralOffset; (offset>0) && (!isStopping()); offset-= (imageSize+rowSize))
             {
-                mutex.wait();
+                mtx.lock();
                 if(-1 == ::write(fd, img->imageData+offset, imageSize) )
                     yError() << "Failed setting image to display";
-                mutex.post();
+                mtx.unlock();
                 yarp::os::Time::delay(1.0);
             }
         }
@@ -560,11 +560,10 @@ void FaceDisplayServer::run()
     // save to file for debugging purpose
     // cv::imwrite(std::string(rootPath + "/runtime/runtime-HappyEye.bmp").c_str(), face);
 
-    mutex.wait();
+    mtx.lock();
     if(-1 == ::write(fd, face.data, faceSize) )
         yError() << "Failed setting image to display";
-    mutex.post();
-
+    mtx.unlock();
 
     // normal workflow
     while(!isStopping())
@@ -839,10 +838,10 @@ void FaceDisplayServer::run()
                 break;
             }
 
-            mutex.wait();
+            mtx.lock();
             if(-1 == ::write(fd, currentFace->data, currentFace->total()*currentFace->elemSize()) )
                 yError() << "Failed setting image to display";
-            mutex.post();
+            mtx.unlock();
         }
     }
 }

--- a/cermod/r1face_mic/r1face_mic.cpp
+++ b/cermod/r1face_mic/r1face_mic.cpp
@@ -24,7 +24,6 @@
 #include <yarp/os/Time.h>
 #include <yarp/os/Value.h>
 #include <yarp/os/LogStream.h>
-#include <yarp/os/LockGuard.h>
 
 #define SLEEP_TIME 0.005f
 
@@ -267,7 +266,7 @@ bool R1faceMic::getSound(yarp::sig::Sound& sound, size_t min_number_of_samples, 
 bool R1faceMic::startRecording()
 {
     if (m_isRecording == true) return true;
-    LockGuard lock(m_mutex);
+    lock_guard<mutex> lock(m_mutex);
     m_isRecording = true;
 #ifdef BUFFER_AUTOCLEAR
     inputBuffer->clear();
@@ -280,7 +279,7 @@ bool R1faceMic::startRecording()
 bool R1faceMic::stopRecording()
 {
     if (m_isRecording == false) return true;
-    LockGuard lock(m_mutex);
+    lock_guard<mutex> lock(m_mutex);
     m_isRecording = false;
 #ifdef BUFFER_AUTOCLEAR
     inputBuffer->clear();
@@ -325,7 +324,7 @@ bool R1faceMic::getRecordingAudioBufferCurrentSize(yarp::dev::AudioBufferSize& s
 
 bool R1faceMic::resetRecordingAudioBuffer()
 {
-    LockGuard lock(m_mutex);
+    lock_guard<mutex> lock(m_mutex);
     inputBuffer->clear();
     yDebug() << "R1faceMic::resetRecordingAudioBuffer";
     return true;

--- a/cermod/r1face_mic/r1face_mic.h
+++ b/cermod/r1face_mic/r1face_mic.h
@@ -7,6 +7,7 @@
  */
 
 #include <atomic>
+#include <mutex>
 
 #include <yarp/dev/CircularAudioBuffer.h>
 
@@ -115,7 +116,7 @@ private:
     int selected_chan;
     int userChannelsNum;
     size_t record_waiting_counter;
-    yarp::os::Mutex m_mutex;
+    std::mutex m_mutex;
 
     int32_t                     *rawBuffer;
     inputData                   *tmpData;

--- a/cermod/tripod/tripodMotionControl.cpp
+++ b/cermod/tripod/tripodMotionControl.cpp
@@ -921,10 +921,9 @@ bool tripodMotionControl::getJointType(int axis, yarp::dev::JointTypeEnum& type)
 bool tripodMotionControl::refreshEncoders(double *times)
 {
     bool ret = false;
-    _mutex.wait();
+    lock_guard<mutex> lg(_mutex);
     if(!_device.iJntEnc)
     {
-        _mutex.post();
         return true;
     }
     if(times !=  NULL)
@@ -955,7 +954,6 @@ bool tripodMotionControl::refreshEncoders(double *times)
         // Becareful of overflowing of error messages
         yError() << "TripodMotionControl: error updating encoders";
     }
-    _mutex.post();
     return ret;
 }
 
@@ -1156,7 +1154,7 @@ bool tripodMotionControl::positionMoveRaw(int j, double ref)
     bool ret = true;  // private var
 
     // calling IK library before propagate the command to HW
-    _mutex.wait();
+    lock_guard<mutex> lg(_mutex);
     _userRef_positions[j] = ref;
 
     if(_directionHW2User)
@@ -1181,14 +1179,13 @@ bool tripodMotionControl::positionMoveRaw(int j, double ref)
 
     ret &= _device.pos->positionMove(_njoints, _axisMap,_robotRef_positions.data());
 
-    _mutex.post();
     return ret;
 }
 
 bool tripodMotionControl::positionMoveRaw(const double *refs)
 {
     bool ret = true;
-    _mutex.wait();
+    lock_guard<mutex> lg(_mutex);
     for(int i=0, index=0; i< _njoints; i++, index++)
     {
         _userRef_positions[i] = refs[i];
@@ -1208,7 +1205,6 @@ bool tripodMotionControl::positionMoveRaw(const double *refs)
             yError() << "Requested position is not reachable";
         }
     }
-    _mutex.post();
 
     compute_speeds(_robotRef_positions, _lastRobot_encoders);
     // all joints may need to move in order to achieve the new requested position
@@ -1216,7 +1212,6 @@ bool tripodMotionControl::positionMoveRaw(const double *refs)
     ret &= _device.pos->setRefSpeeds(_njoints, _axisMap, _robotRef_speeds.data());
     ret &= _device.pos->positionMove(_njoints, _axisMap,_robotRef_positions.data());
 
-    _mutex.post();
     return ret;
 }
 
@@ -1224,7 +1219,7 @@ bool tripodMotionControl::relativeMoveRaw(int j, double delta)
 {
     bool ret = true;
 
-    _mutex.wait();
+    lock_guard<mutex> lg(_mutex);
     // TODO does it make any sense to add values likt this?? Those could be angle or quaternion or whatever!!!!
     // How to sum those up depends on the chosen representation!! Verify and maybe add a parameter in config files
     // to specify the type and choose correct sum procedure
@@ -1245,7 +1240,6 @@ bool tripodMotionControl::relativeMoveRaw(int j, double delta)
             yError() << "Requested position is not reachable";
         }
     }
-    _mutex.post();
 
     compute_speeds(_robotRef_positions, _lastRobot_encoders);
     // all joints may need to move in order to achieve the new requested position
@@ -1253,7 +1247,6 @@ bool tripodMotionControl::relativeMoveRaw(int j, double delta)
     ret &= _device.pos->setRefSpeeds(_njoints, _axisMap, _robotRef_speeds.data());
     ret &= _device.pos->positionMove(_njoints, _axisMap,_robotRef_positions.data());
 
-    _mutex.post();
     return ret;
 }
 
@@ -1264,7 +1257,7 @@ bool tripodMotionControl::relativeMoveRaw(const double *deltas)
     // TODO does it make any sense to add values like this?? Those could be angle or quaternion or whatever!!!!
     // How to sum those up depends on the chosen representation!! Verify and maybe add a parameter in config files
     // to specify the type and choose correct sum procedure
-    _mutex.wait();
+    lock_guard<mutex> lg(_mutex);
     for(int i=0; i<_njoints; i++)
         _userRef_positions[i] += deltas[i];
 
@@ -1283,7 +1276,6 @@ bool tripodMotionControl::relativeMoveRaw(const double *deltas)
             yError() << "Requested position is not reachable";
         }
     }
-    _mutex.post();
 
     compute_speeds(_robotRef_positions, _lastRobot_encoders);
     // all joints may need to move in order to achieve the new requested position
@@ -1291,7 +1283,6 @@ bool tripodMotionControl::relativeMoveRaw(const double *deltas)
     ret &= _device.pos->setRefSpeeds(_njoints, _axisMap, _robotRef_speeds.data());
     ret &= _device.pos->positionMove(_njoints, _axisMap,_robotRef_positions.data());
 
-    _mutex.post();
     return ret;
 }
 
@@ -1434,7 +1425,7 @@ bool tripodMotionControl::positionMoveRaw(const int n_joint, const int *joints, 
         return false;
     }
 
-    _mutex.wait();
+    lock_guard<mutex> lg(_mutex);
     for(int i=0, index=0; i< n_joint; i++, index++)
     {
         _userRef_positions[joints[i]] = refs[i];
@@ -1454,7 +1445,6 @@ bool tripodMotionControl::positionMoveRaw(const int n_joint, const int *joints, 
             yError() << "Requested position is not reachable";
         }
     }
-    _mutex.post();
 
     compute_speeds(_robotRef_positions, _lastRobot_encoders);
     // all joints may need to move in order to achieve the new requested position
@@ -1462,7 +1452,6 @@ bool tripodMotionControl::positionMoveRaw(const int n_joint, const int *joints, 
     ret &= _device.pos->setRefSpeeds(_njoints, _axisMap, _robotRef_speeds.data());
     ret &= _device.pos->positionMove(_njoints, _axisMap, _robotRef_positions.data());
 
-    _mutex.post();
     return ret;
 }
 
@@ -1479,7 +1468,7 @@ bool tripodMotionControl::relativeMoveRaw(const int n_joint, const int *joints, 
         return false;
     }
 
-    _mutex.wait();
+    lock_guard<mutex> lg(_mutex);
     for(int i=0, index=0; i< n_joint; i++, index++)
     {
         _userRef_positions[joints[i]] += deltas[i];
@@ -1499,7 +1488,6 @@ bool tripodMotionControl::relativeMoveRaw(const int n_joint, const int *joints, 
             yError() << "Requested position is not reachable";
         }
     }
-    _mutex.post();
 
     compute_speeds(_robotRef_positions, _lastRobot_encoders);
     // all joints may need to move in order to achieve the new requested position
@@ -1507,7 +1495,6 @@ bool tripodMotionControl::relativeMoveRaw(const int n_joint, const int *joints, 
     ret &= _device.pos->setRefSpeeds(_njoints, _axisMap, _robotRef_speeds.data());
     ret &= _device.pos->positionMove(_njoints, _axisMap, _robotRef_positions.data());
 
-    _mutex.post();
     return ret;
 }
 
@@ -2020,7 +2007,7 @@ bool tripodMotionControl::setPositionRaw(int j, double ref)
         return false;
 
     // calling IK library before propagate the command to HW
-    _mutex.wait();
+    lock_guard<mutex> lg(_mutex);
     _userRef_positions[j] = ref;
     if(_directionHW2User)
     {
@@ -2036,7 +2023,6 @@ bool tripodMotionControl::setPositionRaw(int j, double ref)
             yError() << "Requested position is not reachable";
         }
     }
-    _mutex.post();
 
     // all joints may need to move in order to achieve the new requested position
     // even if only one user virtual joint has got new reference
@@ -2055,7 +2041,7 @@ bool tripodMotionControl::setPositionsRaw(const int n_joint, const int *joints, 
     }
 
     // calling IK library before propagate the command to HW
-    _mutex.wait();
+    lock_guard<mutex> lg(_mutex);
     for(int i=0; i<n_joint; i++)
         _userRef_positions[joints[i]] = refs[i];
 
@@ -2073,7 +2059,6 @@ bool tripodMotionControl::setPositionsRaw(const int n_joint, const int *joints, 
             yError() << "Requested position is not reachable";
         }
     }
-    _mutex.post();
 
     // all joints may need to move in order to achieve the new requested position
     // even if only one user virtual joint has got new reference
@@ -2083,7 +2068,7 @@ bool tripodMotionControl::setPositionsRaw(const int n_joint, const int *joints, 
 bool tripodMotionControl::setPositionsRaw(const double *refs)
 {
     // calling IK library before propagate the command to HW
-    _mutex.wait();
+    lock_guard<mutex> lg(_mutex);
     memcpy(_userRef_positions.data(), refs, _njoints*sizeof(double));
 
     if(_directionHW2User)
@@ -2100,7 +2085,6 @@ bool tripodMotionControl::setPositionsRaw(const double *refs)
             yError() << "Requested position is not reachable";
         }
     }
-    _mutex.post();
 
     // all joints may need to move in order to achieve the new requested position
     // even if only one user virtual joint has got new reference

--- a/cermod/tripod/tripodMotionControl.h
+++ b/cermod/tripod/tripodMotionControl.h
@@ -20,13 +20,13 @@
 
 //  Yarp stuff
 #include <stdint.h>
+#include <mutex>
 #include <vector>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/Time.h>
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/Wrapper.h>
-#include <yarp/os/Semaphore.h>
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/dev/ControlBoardInterfacesImpl.h>
 
@@ -223,7 +223,7 @@ private:
                                        * if FALSE then we wait for the 'attachAll' function to be called in order to get the pointer to the
                                        * low-level device like canBus/embObjMotionControl. */
 
-    yarp::os::Semaphore                      _mutex;
+    std::mutex                              _mutex;
 
     /* Set the direction of conversion: user2HW true means commands are converted from user perspective to
      * low-level HW implementation, i.e. from heave+angles into 3 elongations.
@@ -309,8 +309,7 @@ public:
     virtual bool detachAll();
 
     bool refreshEncoders(double *times);
-    Semaphore               semaphore;
-    std::string   deviceDescription;
+    std::string deviceDescription;
 
     /////////   Axis info INTERFACE   /////////
     virtual bool getAxisName(int axis, std::string& name) override;

--- a/gazeboYarpPlugin/GazeboTripodMotionControl.h
+++ b/gazeboYarpPlugin/GazeboTripodMotionControl.h
@@ -27,7 +27,6 @@
 #include <yarp/dev/IInteractionMode.h>
 #include <yarp/sig/Vector.h>
 #include <yarp/os/Time.h>
-#include <yarp/os/Semaphore.h>
 #include <yarp/os/Stamp.h>
 #include <yarp/dev/IPidControl.h>
 #include <string>

--- a/libraries/cer_kinematics/include/cer_kinematics/utils.h
+++ b/libraries/cer_kinematics/include/cer_kinematics/utils.h
@@ -18,11 +18,11 @@
 #ifndef __CER_KINEMATICS_UTILS_H__
 #define __CER_KINEMATICS_UTILS_H__
 
+#include <mutex>
 #include <limits>
 #include <string>
 #include <set>
 
-#include <yarp/os/Mutex.h>
 #include <yarp/sig/Matrix.h>
 #include <yarp/math/Math.h>
 #include <iCub/iKin/iKinFwd.h>
@@ -365,7 +365,7 @@ public:
 class Solver
 {
 protected:
-    static yarp::os::Mutex makeThreadSafe;
+    static std::mutex makeThreadSafe;
     SolverIterateCallback *callback;
     int verbosity;
 

--- a/libraries/cer_kinematics/src/arm.cpp
+++ b/libraries/cer_kinematics/src/arm.cpp
@@ -23,7 +23,6 @@
 
 #include <yarp/os/LogStream.h>
 #include <yarp/os/Time.h>
-#include <yarp/os/LockGuard.h>
 #include <yarp/math/Math.h>
 
 #include <iCub/ctrl/math.h>
@@ -109,7 +108,7 @@ bool ArmSolver::fkin(const Vector &q, Matrix &H, const int frame)
 /****************************************************************/
 bool ArmSolver::ikin(const Matrix &Hd, Vector &q, int *exit_code)
 {
-    LockGuard lg(makeThreadSafe);
+    lock_guard<mutex> lg(makeThreadSafe);
     yAssert((Hd.rows()==4)&&(Hd.cols()==4));
 
     int mode=computeMode();

--- a/libraries/cer_kinematics/src/head.cpp
+++ b/libraries/cer_kinematics/src/head.cpp
@@ -20,7 +20,6 @@
 
 #include <yarp/os/LogStream.h>
 #include <yarp/os/Time.h>
-#include <yarp/os/LockGuard.h>
 #include <yarp/math/Math.h>
 
 #include <iCub/ctrl/math.h>
@@ -296,7 +295,7 @@ bool HeadSolver::fkin(const Vector &q, Matrix &H, const int frame)
 /****************************************************************/
 bool HeadSolver::ikin(const Vector &xd, Vector &q, int *exit_code)
 {
-    LockGuard lg(makeThreadSafe);
+    lock_guard<mutex> lg(makeThreadSafe);
     yAssert(xd.length()==3);
 
     int print_level=std::max(verbosity-5,0);

--- a/libraries/cer_kinematics/src/tripod.cpp
+++ b/libraries/cer_kinematics/src/tripod.cpp
@@ -21,7 +21,6 @@
 
 #include <yarp/os/LogStream.h>
 #include <yarp/os/Time.h>
-#include <yarp/os/LockGuard.h>
 #include <yarp/sig/Vector.h>
 #include <yarp/sig/Matrix.h>
 #include <yarp/math/Math.h>
@@ -386,7 +385,7 @@ bool TripodSolver::fkin(const Vector &q, Matrix &H, const int frame)
 bool TripodSolver::ikin(const double zd, const Vector &ud,
                         Vector &lll, int *exit_code)
 {
-    LockGuard lg(makeThreadSafe);
+    lock_guard<mutex> lg(makeThreadSafe);
     yAssert(ud.length()>=4);
 
     int print_level=std::max(verbosity-5,0);

--- a/libraries/cer_kinematics/src/utils.cpp
+++ b/libraries/cer_kinematics/src/utils.cpp
@@ -32,7 +32,7 @@ using namespace cer::kinematics;
 namespace cer {
 namespace kinematics {
 
-yarp::os::Mutex Solver::makeThreadSafe;
+std::mutex Solver::makeThreadSafe;
 
 /****************************************************************/
 bool stepModeParser(string &mode, string &submode)

--- a/libraries/cer_mobile_kinematics/include/cer_mobile_kinematics/mobile_utils.h
+++ b/libraries/cer_mobile_kinematics/include/cer_mobile_kinematics/mobile_utils.h
@@ -22,7 +22,6 @@
 #include <string>
 #include <set>
 
-#include <yarp/os/Mutex.h>
 #include <yarp/sig/Matrix.h>
 #include <yarp/math/Math.h>
 #include <iCub/iKin/iKinFwd.h>

--- a/libraries/cer_mobile_kinematics/src/mobile_arm.cpp
+++ b/libraries/cer_mobile_kinematics/src/mobile_arm.cpp
@@ -23,7 +23,6 @@
 
 #include <yarp/os/LogStream.h>
 #include <yarp/os/Time.h>
-#include <yarp/os/LockGuard.h>
 #include <yarp/math/Math.h>
 #include <yarp/math/SVD.h>
 
@@ -107,7 +106,7 @@ bool MobileArmSolver::fkin(const Vector &q, Matrix &H, const int frame)
 /****************************************************************/
 bool MobileArmSolver::ikin(const vector<Matrix> &Hd, Vector &q, int *exit_code)
 {
-    LockGuard lg(makeThreadSafe);
+    lock_guard<mutex> lg(makeThreadSafe);
     for(size_t i=0; i<Hd.size(); i++)
         yAssert((Hd[i].rows()==4)&&(Hd[i].cols()==4));
 

--- a/modules/faceExpression/faceExpressionImage.cpp
+++ b/modules/faceExpression/faceExpressionImage.cpp
@@ -287,23 +287,20 @@ void BlinkThread::afterStart(bool s) { }
 
 void BlinkThread::activateBars(bool activate)
 {
-    mutex.lock();
+    lock_guard<mutex> lg(mtx);
     doBars = activate;
-    mutex.unlock();
 }
 
 void BlinkThread::activateTalk(bool activate)
 {
-    mutex.lock();
+    lock_guard<mutex> lg(mtx);
     doTalk = activate;
-    mutex.unlock();
 }
 
 void BlinkThread::activateBlink(bool activate)
 {
-    mutex.lock();
+    lock_guard<mutex> lg(mtx);
     doBlink = activate;
-    mutex.unlock();
 }
 
 bool BlinkThread::threadInit()
@@ -357,7 +354,7 @@ void BlinkThread::run()
 		return;
 	}
 	
-    mutex.lock();
+    lock_guard<mutex> lg(mtx);
     // Compute hear bars sizes
     // Left side
     float percentage = 0.5;
@@ -402,8 +399,6 @@ void BlinkThread::run()
             yarp::os::Time::delay(delays[index]);
     }
     while(doBlink);
-    
-    mutex.unlock();
 }
 
 bool BlinkThread::updateBars(float percentage)
@@ -455,25 +450,22 @@ void BlinkThread::updateTalk()
 
 void BlinkThread::threadRelease()
 {
-    mutex.lock();
+    lock_guard<mutex> lg(mtx);
     yarp::sig::ImageOf<yarp::sig::PixelRgb> &img = port.prepare();
     img.setExternal(faceRest.data, faceWidth, faceHeight);
     port.writeStrict();
-    mutex.unlock();
 }
 
 void BlinkThread::activateDraw(bool activate)
 {
-    mutex.lock();
+    lock_guard<mutex> lg(mtx);
     doDraw = activate;
-    mutex.unlock();
 }
 
 void BlinkThread::blackReset()
 {
-    mutex.lock();
+    lock_guard<mutex> lg(mtx);
     yarp::sig::ImageOf<yarp::sig::PixelRgb> &img = port.prepare();
     img.setExternal(faceBlack.data, faceWidth, faceHeight);
     port.writeStrict();
-    mutex.unlock();
 }

--- a/modules/faceExpression/faceExpressionImage.hpp
+++ b/modules/faceExpression/faceExpressionImage.hpp
@@ -1,3 +1,4 @@
+#include <mutex>
 #include <string>
 #include <iostream>
 
@@ -83,7 +84,7 @@ private:
     int index;
     int indexes[11];
     float delays[11];
-    yarp::os::Mutex mutex;
+    std::mutex mtx;
 };
 
 class FaceExpressionImageModule: public yarp::os::RFModule

--- a/modules/mobile-reaching/controller/main.cpp
+++ b/modules/mobile-reaching/controller/main.cpp
@@ -15,6 +15,7 @@
  * Public License for more details
 */
 
+#include <mutex>
 #include <string>
 #include <vector>
 #include <cmath>
@@ -89,7 +90,7 @@ class Controller : public RFModule
     RpcClient solverPort;
     Stamp txInfo;
 
-    Mutex mutex;
+    mutex mtx;
     int verbosity;
     bool closing;
     bool controlling;
@@ -472,7 +473,7 @@ public:
 
         if (request.check("stop"))
         {
-            LockGuard lg(mutex);
+            lock_guard<mutex> lg(mtx);
             stopControl();
             return true;
         }
@@ -496,7 +497,7 @@ public:
                 Bottle *payLoadJoints=payLoadJointsList->get(0).asList();
                 Bottle *payLoadPose=payLoadPoseList->get(0).asList();
 
-                LockGuard lg(mutex);
+                lock_guard<mutex> lg(mtx);
                 // process only if we didn't receive
                 // a stop request in the meanwhile
                 if (controlling==latch_controlling)
@@ -920,7 +921,7 @@ public:
     /****************************************************************/
     bool updateModule()
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         getCurrentMode();        
 
         Matrix Hee;
@@ -988,29 +989,22 @@ public:
                 string cmd_1=cmd.get(1).asString();
                 if (cmd_1=="T")
                 {
-                    mutex.lock();
+                    lock_guard<mutex> lg(mtx);
                     gen->setT(cmd.get(2).asDouble());
-                    mutex.unlock();
-
                     reply.addVocab(Vocab::encode("ack"));
                 }
                 else if (cmd_1=="Ts")
                 {
+                    lock_guard<mutex> lg(mtx);
                     Ts=cmd.get(2).asDouble();
                     Ts=std::max(Ts,MIN_TS);
-
-                    mutex.lock();
                     gen->setTs(Ts);
-                    mutex.unlock();
-
                     reply.addVocab(Vocab::encode("ack"));
                 }
                 else if (cmd_1=="verbosity")
                 {
-                    mutex.lock();
+                    lock_guard<mutex> lg(mtx);
                     verbosity=cmd.get(2).asInt();
-                    mutex.unlock();
-
                     reply.addVocab(Vocab::encode("ack"));
                 }
                 else if (cmd_1=="mode")
@@ -1062,43 +1056,33 @@ public:
                 string cmd_1=cmd.get(1).asString();
                 if (cmd_1=="done")
                 {
+                    lock_guard<mutex> lg(mtx);
                     reply.addVocab(Vocab::encode("ack"));
-
-                    mutex.lock();
                     reply.addInt(controlling?0:1);
-                    mutex.unlock();
                 }
                 else if (cmd_1=="target")
                 {
+                    lock_guard<mutex> lg(mtx);
                     reply.addVocab(Vocab::encode("ack"));
-
-                    mutex.lock();
                     reply.addList()=target;
-                    mutex.unlock();
                 }
                 else if (cmd_1=="T")
                 {
+                    lock_guard<mutex> lg(mtx);
                     reply.addVocab(Vocab::encode("ack"));
-
-                    mutex.lock();
                     reply.addDouble(gen->getT());
-                    mutex.unlock();
                 }
                 else if (cmd_1=="Ts")
                 {
+                    lock_guard<mutex> lg(mtx);
                     reply.addVocab(Vocab::encode("ack"));
-
-                    mutex.lock();
                     reply.addDouble(Ts);
-                    mutex.unlock();
                 }
                 else if (cmd_1=="verbosity")
                 {
+                    lock_guard<mutex> lg(mtx);
                     reply.addVocab(Vocab::encode("ack"));
-
-                    mutex.lock();
                     reply.addInt(verbosity);
-                    mutex.unlock();
                 }
                 else if (cmd_1=="mode")
                 {
@@ -1204,10 +1188,8 @@ public:
         }
         else if (cmd_0==Vocab::encode("stop"))
         {
-            mutex.lock();
+            lock_guard<mutex> lg(mtx);
             stopControl();
-            mutex.unlock();
-
             reply.addVocab(Vocab::encode("ack"));
         }
 

--- a/modules/teleop/handThread.cpp
+++ b/modules/teleop/handThread.cpp
@@ -156,9 +156,8 @@ void HandThread::updateRVIZ(const Vector &xd, const Vector &od)
 
     m = axis2dcm(od);
     m.setSubcol(xd, 0, 3);
-    mutex.lock();
+    mtx.lock();
     criticalSection.tf = m;
-    mutex.unlock();
 
     time      = (uint64_t)(yarpTimeStamp * 1000000000UL);
     nsec_part = (time % 1000000000UL);

--- a/modules/teleop/handThread.h
+++ b/modules/teleop/handThread.h
@@ -1,3 +1,4 @@
+#include <mutex>
 #include <string>
 #include <vector>
 #include <yarp/sig/Matrix.h>
@@ -10,10 +11,8 @@
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/os/Searchable.h>
-#include <yarp/os/Mutex.h>
 #include <yarp/os/Publisher.h>
 #include <yarp/rosmsg/visualization_msgs/MarkerArray.h>
-#include <yarp/os/LockGuard.h>
 
 class HandThread : public yarp::os::PeriodicThread
 {
@@ -52,13 +51,13 @@ public:
 
     yarp::sig::Matrix getMatrix()
     {
-        yarp::os::LockGuard l(mutex);
+        std::lock_guard<std::mutex> lg(mtx);
         return criticalSection.tf;
     }
 
     void         setData(CommandData newdata)
     {
-        mutex.lock();
+        std::lock_guard<std::mutex> lg(mtx);
         criticalSection.absoluteRotation = newdata.absoluteRotation;
         criticalSection.button0          = newdata.button0         ;
         criticalSection.button1          = newdata.button1         ;
@@ -68,7 +67,6 @@ public:
         criticalSection.simultMovRot     = newdata.simultMovRot    ;
         criticalSection.singleButton     = newdata.singleButton    ;
         criticalSection.targetDistance   = newdata.targetDistance  ;
-        mutex.unlock();
     }
     void         setGrabTrigger();
     void         setDragTrigger();
@@ -146,7 +144,7 @@ private:
     double             button1;
     bool               button2;
     int                controlMode;
-    yarp::os::Mutex    mutex;
+    std::mutex         mtx;
     double             gain;
     double             wrist_heave;
     std::string        mode;
@@ -169,7 +167,7 @@ private:
     double getPeriod();
     void   getData()
     {
-        mutex.lock();
+        std::lock_guard<std::mutex> lg(mtx);
         pose             = criticalSection.pose;
         button0          = criticalSection.button0;
         button1          = criticalSection.button1;
@@ -179,7 +177,6 @@ private:
         singleButton     = criticalSection.singleButton;
         simultMovRot     = criticalSection.simultMovRot;
         absoluteRotation = criticalSection.absoluteRotation;
-        mutex.unlock();
     }
 
 };

--- a/tools/kinematics/cer_kinematics-tracking.cpp
+++ b/tools/kinematics/cer_kinematics-tracking.cpp
@@ -16,6 +16,7 @@
 */
 
 #include <cstdio>
+#include <mutex>
 #include <cmath>
 #include <string>
 
@@ -36,7 +37,7 @@ using namespace cer::kinematics;
 /****************************************************************/
 class Target : public PeriodicThread
 {
-    mutable Mutex mutex;
+    mutable mutex mtx;
     Vector c,xd;
     double f,R;
     int cnt;
@@ -53,7 +54,7 @@ class Target : public PeriodicThread
     /****************************************************************/
     void run()
     {
-        LockGuard lg(mutex);        
+        lock_guard<mutex> lg(mtx);
         const double t=Time::now()-t0;
         const double phi=2.0*M_PI*f*t;
 
@@ -91,7 +92,7 @@ public:
     /****************************************************************/
     Vector get_xd(int &cnt) const
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         cnt=this->cnt;
         return xd;
     }
@@ -99,7 +100,7 @@ public:
     /****************************************************************/
     void print(const int cnt, const Vector &x) const
     {
-        LockGuard lg(mutex);
+        lock_guard<mutex> lg(mtx);
         helperPrint(Time::now()-t0,"x",cnt,x);
     }
 };


### PR DESCRIPTION
Given https://github.com/robotology/yarp/pull/2080, this PR replaces `yarp::os::Mutex` and `yarp::os::Semaphore` (only when used as a mutex) with `std::mutex`.