### PR TITLE
fix/cer02

### DIFF
--- a/app/robots/CER02/hardware/mechanicals/cer_base-ems1-mec.xml
+++ b/app/robots/CER02/hardware/mechanicals/cer_base-ems1-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  5 </param>
+        <param name="MotioncontrolVersion"> 6 </param>
         <param name="Joints">  2  </param> 
         <param name="AxisName">          "mobile_base_l_wheel_joint" "mobile_base_r_wheel_joint" </param>
         <param name="AxisMap">               0           1                 </param>

--- a/app/robots/CER02/hardware/mechanicals/cer_head-mcp10-mec.xml
+++ b/app/robots/CER02/hardware/mechanicals/cer_head-mcp10-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  5 </param>
+        <param name="MotioncontrolVersion"> 6 </param>
         <param name="Joints">                2  </param> 
         <param name="AxisName">              "neck_pitch_joint" "neck_yaw_joint" </param>
         <param name="AxisMap">               0                  1                </param>

--- a/app/robots/CER02/hardware/mechanicals/cer_left_hand-mcp9-mec.xml
+++ b/app/robots/CER02/hardware/mechanicals/cer_left_hand-mcp9-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  5 </param>
+        <param name="MotioncontrolVersion"> 6 </param>
         <param name="Joints">                2  </param> 
         <param name="AxisName">              "l_palm"           "l_thumb"       </param>
         <param name="AxisMap">               0                  1               </param>

--- a/app/robots/CER02/hardware/mechanicals/cer_left_lower_arm-mcp8-mec.xml
+++ b/app/robots/CER02/hardware/mechanicals/cer_left_lower_arm-mcp8-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  5 </param>
+        <param name="MotioncontrolVersion"> 6 </param>
         <param name="Joints">                4  </param> 
         <param name="AxisName">              "l_wrist_tripod_0" "l_wrist_tripod_1" "l_wrist_tripod_2" "l_wrist_pronosupination_joint"  </param>
         <param name="AxisMap">               0                  1                  2                  3                        </param>

--- a/app/robots/CER02/hardware/mechanicals/cer_left_shoulder-ems5-mec.xml
+++ b/app/robots/CER02/hardware/mechanicals/cer_left_shoulder-ems5-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">     5             </param>
+        <param name="MotioncontrolVersion"> 6 </param>
         <param name="Joints">                   2             </param> 
         <param name="AxisMap">                  0                            1                          </param>
         <param name="AxisName">                 "l_shoulder_pitch_joint"     "l_shoulder_roll_joint"    </param>

--- a/app/robots/CER02/hardware/mechanicals/cer_left_upper_arm-ems12-mec.xml
+++ b/app/robots/CER02/hardware/mechanicals/cer_left_upper_arm-ems12-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">     5                                       </param>
+        <param name="MotioncontrolVersion"> 6 </param>
         <param name="Joints">                   2                                       </param> 
         <param name="AxisMap">                  0                       1               </param>
         <param name="AxisName">                 "l_shoulder_yaw_joint"  "l_elbow_joint" </param>

--- a/app/robots/CER02/hardware/mechanicals/cer_right_hand-mcp7-mec.xml
+++ b/app/robots/CER02/hardware/mechanicals/cer_right_hand-mcp7-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  5 </param>
+        <param name="MotioncontrolVersion"> 6 </param>
         <param name="Joints">                2  </param> 
         <param name="AxisName">              "r_palm"           "r_thumb"       </param>
         <param name="AxisMap">               0                  1               </param>

--- a/app/robots/CER02/hardware/mechanicals/cer_right_lower_arm-mcp6-mec.xml
+++ b/app/robots/CER02/hardware/mechanicals/cer_right_lower_arm-mcp6-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  5 </param>
+        <param name="MotioncontrolVersion"> 6 </param>
         <param name="Joints">                4  </param> 
         <param name="AxisName">              "r_wrist_tripod_0" "r_wrist_tripod_1" "r_wrist_tripod_2" "r_wrist_pronosupination_joint"</param>
         <param name="AxisMap">               0                  1                  2                  3                       </param>

--- a/app/robots/CER02/hardware/mechanicals/cer_right_shoulder-ems4-mec.xml
+++ b/app/robots/CER02/hardware/mechanicals/cer_right_shoulder-ems4-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">     5             </param>
+        <param name="MotioncontrolVersion"> 6 </param>
         <param name="Joints">                   2             </param> 
         <param name="AxisMap">                  0                             1                                  </param>
         <param name="AxisName">                 "r_shoulder_pitch_joint"      "r_shoulder_roll_joint"            </param>

--- a/app/robots/CER02/hardware/mechanicals/cer_right_upper_arm-ems11-mec.xml
+++ b/app/robots/CER02/hardware/mechanicals/cer_right_upper_arm-ems11-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">     5                                      </param>
+        <param name="MotioncontrolVersion"> 6 </param>
         <param name="Joints">                   2                                      </param> 
         <param name="AxisMap">                  0                      1               </param>
         <param name="AxisName">                 "r_shoulder_yaw_joint" "r_elbow_joint" </param>

--- a/app/robots/CER02/hardware/mechanicals/cer_torso-ems3-mec.xml
+++ b/app/robots/CER02/hardware/mechanicals/cer_torso-ems3-mec.xml
@@ -3,7 +3,7 @@
 
 <params xmlns:xi="http://www.w3.org/2001/XInclude" robot="CER02" build="1">
     <group name="GENERAL">
-        <param name="MotioncontrolVersion">  5 </param>
+        <param name="MotioncontrolVersion"> 6 </param>
         <param name="Joints">                4  </param> 
         <param name="AxisName">              "torso_tripod_0" "torso_tripod_1" "torso_tripod_2" "torso_yaw_joint" </param>
         <param name="AxisMap">               0            1            2             3             </param>


### PR DESCRIPTION
[cer02] fixed MotioncontrolVersion (5->6), fixed the required fw version for 2foc board (0.0.0->3.3.3)

comments:

1. i left the *-mc.xml files unchanged because the format is already in new fmi syntax.

2. the ordering of the sections of the files *-mc.xml is not the one as required by robots-configuration,
   hence we should regularize it.

3. the xml files of robot cer01 are already in the new fmi syntax but must have: mcv 5->6 and 2foc with v3.3.3

4. the xml files of robot cer03 are not in the new fmi syntax yet.

