### PR TITLE
Fix for yarp master compatibility

### DIFF
--- a/cermod/cerDoubleLidar/cerDoubleLidar.h
+++ b/cermod/cerDoubleLidar/cerDoubleLidar.h
@@ -66,14 +66,14 @@ public:
 
     bool open(yarp::os::Searchable& config);
     bool close();
-    
+
     //IMultipleWrapper interface
     bool attachAll(const yarp::dev::PolyDriverList &p) override;
     bool detachAll() override;
-    
+
     //IRangefinder2D interface
     virtual bool getRawData          (yarp::sig::Vector& data, double* timestamp = nullptr) override;
-    virtual bool getLaserMeasurement (std::vector<yarp::dev::LaserMeasurementData>& data, double* timestamp = nullptr) override;
+    virtual bool getLaserMeasurement (std::vector<yarp::sig::LaserMeasurementData>& data, double* timestamp = nullptr) override;
     virtual bool setDistanceRange    (double min, double max) override;
     virtual bool setScanLimits        (double min, double max) override;
     virtual bool setHorizontalResolution      (double step) override;

--- a/cermod/r1face_mic/r1face_mic.cpp
+++ b/cermod/r1face_mic/r1face_mic.cpp
@@ -65,11 +65,11 @@ R1faceMic::R1faceMic(): PeriodicThread(0),
                         userChannelsNum(8)
 {
     tmpData     = new inputData;
-    
+
     const size_t _channels = HW_STEREO_CHANNELS * STEREO;
     const size_t _samples = BUFFER_SIZE * CHUNK_SIZE;
     const size_t _depth = 4;
-    yarp::dev::AudioBufferSize size (_samples, _channels, _depth);
+    yarp::sig::AudioBufferSize size (_samples, _channels, _depth);
     inputBuffer = new CircularAudioBuffer_32t("r1_face_mic",size);
     record_waiting_counter=0;
 }
@@ -229,7 +229,7 @@ bool R1faceMic::getSound(yarp::sig::Sound& sound, size_t min_number_of_samples, 
     }
     sound.setFrequency(samplingRate);
     sound.clear();
-    
+
     ///////////////////////////////////////////////
     // Extract channels from acquired buffer and
     // manipulate them to get meaningful information
@@ -308,7 +308,7 @@ bool R1faceMic::stopService()
     return false;
 }
 
-bool R1faceMic::getRecordingAudioBufferMaxSize(yarp::dev::AudioBufferSize& size)
+bool R1faceMic::getRecordingAudioBufferMaxSize(yarp::sig::AudioBufferSize& size)
 {
     //no lock guard is needed here
     size = this->inputBuffer->getMaxSize();
@@ -316,7 +316,7 @@ bool R1faceMic::getRecordingAudioBufferMaxSize(yarp::dev::AudioBufferSize& size)
 }
 
 
-bool R1faceMic::getRecordingAudioBufferCurrentSize(yarp::dev::AudioBufferSize& size)
+bool R1faceMic::getRecordingAudioBufferCurrentSize(yarp::sig::AudioBufferSize& size)
 {
     //no lock guard is needed here
     size = this->inputBuffer->size();
@@ -329,5 +329,29 @@ bool R1faceMic::resetRecordingAudioBuffer()
     lock_guard<mutex> lock(m_mutex);
     inputBuffer->clear();
     yDebug() << "R1faceMic::resetRecordingAudioBuffer";
+    return true;
+}
+
+bool R1faceMic::isRecording(bool& recording_enabled)
+{
+    YARP_UNUSED(recording_enabled);
+    yWarning() << "isRecording Not implemented yet";
+
+    return true;
+}
+
+bool R1faceMic::setSWGain(double gain)
+{
+    YARP_UNUSED(gain);
+    yWarning() << "setSWGain Not implemented yet";
+
+    return true;
+}
+
+bool R1faceMic::setHWGain(double gain)
+{
+    YARP_UNUSED(gain);
+    yWarning() << "setHWGain Not implemented yet";
+
     return true;
 }

--- a/cermod/r1face_mic/r1face_mic.h
+++ b/cermod/r1face_mic/r1face_mic.h
@@ -98,9 +98,15 @@ public:
      */
     virtual bool stopRecording() override;
 
-    virtual bool getRecordingAudioBufferMaxSize(yarp::dev::AudioBufferSize& size) override;
+    bool isRecording(bool& recording_enabled) override;
 
-    virtual bool getRecordingAudioBufferCurrentSize(yarp::dev::AudioBufferSize& size) override;
+    bool setSWGain(double gain) override;
+
+    bool setHWGain(double gain) override;
+
+    virtual bool getRecordingAudioBufferMaxSize(yarp::sig::AudioBufferSize& size) override;
+
+    virtual bool getRecordingAudioBufferCurrentSize(yarp::sig::AudioBufferSize& size) override;
 
     virtual bool resetRecordingAudioBuffer() override;
 

--- a/modules/faceExpression/drawingThread.hpp
+++ b/modules/faceExpression/drawingThread.hpp
@@ -16,8 +16,8 @@
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/ResourceFinder.h>
-#include <yarp/dev/AudioRecorderStatus.h>
-#include <yarp/dev/AudioPlayerStatus.h>
+#include <yarp/sig/AudioRecorderStatus.h>
+#include <yarp/sig/AudioPlayerStatus.h>
 
 #define VOCAB_AUDIO_START       yarp::os::createVocab32('a','s','t','a')
 #define VOCAB_AUDIO_STOP        yarp::os::createVocab32('a','s','t','o')

--- a/modules/faceExpression/earsThread.cpp
+++ b/modules/faceExpression/earsThread.cpp
@@ -85,7 +85,7 @@ void EarsThread::run()
 
     float percentage = 0.5;
 
-    yarp::dev::AudioRecorderStatus* Rstatus = m_audioRecPort.read(false);
+    yarp::sig::AudioRecorderStatus* Rstatus = m_audioRecPort.read(false);
     if (Rstatus)
     {
         m_audioIsRecording=Rstatus->enabled;

--- a/modules/faceExpression/earsThread.hpp
+++ b/modules/faceExpression/earsThread.hpp
@@ -15,8 +15,8 @@
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/ResourceFinder.h>
-#include <yarp/dev/AudioRecorderStatus.h>
-#include <yarp/dev/AudioPlayerStatus.h>
+#include <yarp/sig/AudioRecorderStatus.h>
+#include <yarp/sig/AudioPlayerStatus.h>
 
 #define VOCAB_AUDIO_START       yarp::os::createVocab32('a','s','t','a')
 #define VOCAB_AUDIO_STOP        yarp::os::createVocab32('a','s','t','o')
@@ -33,7 +33,7 @@ public:
 
 private:
     yarp::os::ResourceFinder& m_rf;
-    yarp::os::BufferedPort<yarp::dev::AudioRecorderStatus > m_audioRecPort;
+    yarp::os::BufferedPort<yarp::sig::AudioRecorderStatus > m_audioRecPort;
     std::mutex&             m_drawing_mutex;
     std::recursive_mutex    m_methods_mutex;
     std::string             m_imagePath;

--- a/modules/faceExpression/eyesThread.hpp
+++ b/modules/faceExpression/eyesThread.hpp
@@ -15,8 +15,8 @@
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/ResourceFinder.h>
-#include <yarp/dev/AudioRecorderStatus.h>
-#include <yarp/dev/AudioPlayerStatus.h>
+#include <yarp/sig/AudioRecorderStatus.h>
+#include <yarp/sig/AudioPlayerStatus.h>
 
 #define VOCAB_AUDIO_START       yarp::os::createVocab32('a','s','t','a')
 #define VOCAB_AUDIO_STOP        yarp::os::createVocab32('a','s','t','o')
@@ -54,7 +54,7 @@ private:
     // Offset values for placing stuff and size
     int eyeWidth=21;
     int eyeHeight=14;
-    
+
     // Where to place the eyes
     float leftEye_x=9;
     float leftEye_y=9;

--- a/modules/faceExpression/mouthThread.cpp
+++ b/modules/faceExpression/mouthThread.cpp
@@ -61,7 +61,7 @@ void MouthThread::run()
     lock_guard<recursive_mutex> lg(m_methods_mutex);
 
     //get the status
-    yarp::dev::AudioPlayerStatus* Pstatus = m_audioPlayPort.read(false);
+    yarp::sig::AudioPlayerStatus* Pstatus = m_audioPlayPort.read(false);
     if (Pstatus)
     {
         m_audioIsPlaying= Pstatus->enabled;

--- a/modules/faceExpression/mouthThread.hpp
+++ b/modules/faceExpression/mouthThread.hpp
@@ -15,8 +15,8 @@
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/ResourceFinder.h>
-#include <yarp/dev/AudioRecorderStatus.h>
-#include <yarp/dev/AudioPlayerStatus.h>
+#include <yarp/sig/AudioRecorderStatus.h>
+#include <yarp/sig/AudioPlayerStatus.h>
 
 #define VOCAB_AUDIO_START       yarp::os::createVocab32('a','s','t','a')
 #define VOCAB_AUDIO_STOP        yarp::os::createVocab32('a','s','t','o')
@@ -33,7 +33,7 @@ public:
 
 private:
     yarp::os::ResourceFinder& m_rf;
-    yarp::os::BufferedPort<yarp::dev::AudioPlayerStatus > m_audioPlayPort;
+    yarp::os::BufferedPort<yarp::sig::AudioPlayerStatus > m_audioPlayPort;
     std::mutex&             m_drawing_mutex;
     std::recursive_mutex    m_methods_mutex;
     std::string             m_imagePath;


### PR DESCRIPTION
Classes fixed to allow building `cer` repo with `yarp master`:

- CerDoubleLidar
- r1face_mic
- DrawingThread
- EarsThread
- EyesThread
- MouthThread